### PR TITLE
Use common OpenRouter base URL

### DIFF
--- a/modules/config.py
+++ b/modules/config.py
@@ -34,6 +34,10 @@ LLM_MODEL = _get_env("LLM_MODEL", "gemini-1.5-flash-latest")
 GOOGLE_API_KEY = _get_env("GOOGLE_API_KEY")
 OPENROUTER_API_KEY = _get_env("OPENROUTER_API_KEY")
 
+# --- Base URL cho OpenRouter API ---
+# Dùng chung cho mọi client và fetcher
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+
 # --- Cấu hình email (không bắt buộc) ---
 EMAIL_HOST = _get_env("EMAIL_HOST", "imap.gmail.com")
 # EMAIL_PORT: làm sạch comment và chuyển sang int, mặc định 993

--- a/modules/dynamic_llm_client.py
+++ b/modules/dynamic_llm_client.py
@@ -6,7 +6,7 @@ import streamlit as st  # lấy thông tin session_state trong Streamlit
 import logging  # ghi log xử lý
 from typing import List  # định nghĩa kiểu cho danh sách
 
-from .config import LLM_CONFIG  # cấu hình chung LLM từ modules/config.py
+from .config import LLM_CONFIG, OPENROUTER_BASE_URL  # cấu hình chung LLM và URL
 
 # --- Thiết lập logger cho module dynamic_llm_client ---
 logger = logging.getLogger(__name__)  # lấy logger theo tên module
@@ -116,8 +116,7 @@ class DynamicLLMClient:
 
         try:
             # Gửi POST request, timeout 30s
-            # Correct base URL for chat completions
-            url = "https://api.openrouter.ai/v1/chat/completions"
+            url = f"{OPENROUTER_BASE_URL}/chat/completions"
             res = requests.post(
                 url,
                 json=payload,

--- a/modules/llm_client.py
+++ b/modules/llm_client.py
@@ -6,7 +6,7 @@ import logging                     # thư viện ghi log
 import requests                    # thư viện HTTP để gửi yêu cầu tới API OpenRouter
 from typing import List           # khai báo kiểu List cho Python 3.8+
 
-from .config import LLM_CONFIG     # import cấu hình chung LLM từ file config.py
+from .config import LLM_CONFIG, OPENROUTER_BASE_URL  # import cấu hình LLM và URL chung
 
 # --- Thiết lập logger cho module llm_client ---
 logger = logging.getLogger(__name__)        # lấy logger theo tên module hiện tại
@@ -97,7 +97,7 @@ class LLMClient:
         try:
             # Gửi POST request, timeout 30s
             res = requests.post(
-                "https://openrouter.ai/api/v1/chat/completions",
+                f"{OPENROUTER_BASE_URL}/chat/completions",
                 json=payload,
                 headers=headers,
                 timeout=30


### PR DESCRIPTION
## Summary
- define `OPENROUTER_BASE_URL` in `config.py`
- use the shared constant in `llm_client` and `dynamic_llm_client`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850dcc0f490832482d254a9b60b2794

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Centralized the OpenRouter API base URL configuration, allowing for easier management of the endpoint used by OpenRouter clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->