### PR TITLE
Add auto email fetcher

### DIFF
--- a/modules/auto_fetcher.py
+++ b/modules/auto_fetcher.py
@@ -1,0 +1,47 @@
+# modules/auto_fetcher.py
+"""Chạy EmailFetcher liên tục với khoảng nghỉ tuỳ chọn."""
+
+import time
+import logging
+import argparse
+
+from .email_fetcher import EmailFetcher
+
+
+def watch_loop(interval: int) -> None:
+    """Kết nối IMAP và gọi fetch_cv_attachments() liên tục."""
+    fetcher = EmailFetcher()
+    fetcher.connect()
+    logging.info(f"Bắt đầu auto fetch, interval={interval}s")
+
+    try:
+        while True:
+            try:
+                fetcher.fetch_cv_attachments()
+            except Exception as e:  # bắt mọi lỗi để không dừng vòng lặp
+                logging.error(f"Lỗi fetch: {e}")
+            time.sleep(interval)
+    except KeyboardInterrupt:
+        logging.info("Đã dừng auto fetch")
+    finally:
+        if fetcher.mail:
+            try:
+                fetcher.mail.logout()
+            except Exception:
+                pass
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Tự động fetch CV từ email")
+    parser.add_argument(
+        "--interval",
+        type=int,
+        default=600,
+        help="Khoảng thời gian (giây) giữa các lần quét",
+    )
+    args = parser.parse_args()
+    watch_loop(args.interval)
+
+
+if __name__ == "__main__":
+    main()

--- a/readme.md
+++ b/readme.md
@@ -144,6 +144,8 @@ streamlit run main_engine/app.py
 python main_engine/main.py --batch
 # Hoặc xử lý file đơn
 python main_engine/main.py --single path/to/cv.pdf
+# Theo dõi email liên tục (mặc định 600s)
+python modules/auto_fetcher.py --interval 600
 ```
 
 ### 3. Chọn TOP 5 CV


### PR DESCRIPTION
## Summary
- create `modules/auto_fetcher.py` that continuously calls `EmailFetcher`
- document new CLI command in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685110d2ee5083248bbbe45863b52b2b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a script for continuous email monitoring with a configurable polling interval.

- **Documentation**
  - Added usage instructions for the new continuous email monitoring feature in the CLI section of the README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->