### PR TITLE
Update output ordering and display

### DIFF
--- a/main_engine/app.py
+++ b/main_engine/app.py
@@ -212,13 +212,25 @@ with tab_process:
                     "Họ tên": info.get("ten", ""),
                     "Email": info.get("email", ""),
                     "Điện thoại": info.get("dien_thoai", ""),
+                    "Địa chỉ": info.get("dia_chi", ""),
                     "Học vấn": info.get("hoc_van", ""),
                     "Kinh nghiệm": info.get("kinh_nghiem", ""),
-                    "Địa chỉ": info.get("dia_chi", ""),
                     "Kỹ năng": info.get("ky_nang", ""),
                 })
                 progress.progress(idx/total)
-            df = pd.DataFrame(results)
+            df = pd.DataFrame(
+                results,
+                columns=[
+                    "Nguồn",
+                    "Họ tên",
+                    "Email",
+                    "Điện thoại",
+                    "Địa chỉ",
+                    "Học vấn",
+                    "Kinh nghiệm",
+                    "Kỹ năng",
+                ],
+            )
             processor.save_to_csv(df, str(OUTPUT_CSV))
             st.success(f"Đã xử lý {len(df)} CV và lưu vào `{OUTPUT_CSV.name}`.")
 

--- a/modules/cv_processor.py
+++ b/modules/cv_processor.py
@@ -8,6 +8,7 @@ import logging  # ghi log
 from typing import List, Dict, Optional  # khai báo kiểu
 
 import pandas as pd  # xử lý DataFrame
+pd.set_option("display.max_colwidth", None)  # hiển thị đầy đủ nội dung các cột
 import docx  # đọc file .docx
 
 # --- Thiết lập logger cho module ---
@@ -174,13 +175,22 @@ class CVProcessor:
                 "Họ tên": info.get("ten", ""),
                 "Email": info.get("email", ""),
                 "Điện thoại": info.get("dien_thoai", ""),
+                "Địa chỉ": info.get("dia_chi", ""),
                 "Học vấn": info.get("hoc_van", ""),
                 "Kinh nghiệm": info.get("kinh_nghiem", ""),
-                "Địa chỉ": info.get("dia_chi", ""),
                 "Kỹ năng": info.get("ky_nang", ""),
             })
 
-        df = pd.DataFrame(rows)  # tạo DataFrame từ list dict
+        df = pd.DataFrame(rows, columns=[
+            "Nguồn",
+            "Họ tên",
+            "Email",
+            "Điện thoại",
+            "Địa chỉ",
+            "Học vấn",
+            "Kinh nghiệm",
+            "Kỹ năng",
+        ])  # tạo DataFrame từ list dict với thứ tự cột cố định
         return df  # trả về kết quả
 
     def save_to_csv(self, df: pd.DataFrame, output: str = OUTPUT_CSV):

--- a/static/style.css
+++ b/static/style.css
@@ -78,3 +78,10 @@ button[data-baseweb="base-button"]:hover {
   background-color: var(--cv-bg-color) !important;
   color: var(--cv-text-color) !important;
 }
+
+/* Wrap text in DataFrame cells for readability */
+div[data-testid="stDataFrame"] td {
+  white-space: pre-wrap !important;
+  word-break: break-word !important;
+  max-width: 300px;
+}


### PR DESCRIPTION
## Summary
- keep long column values visible in dataframes
- reorder extracted fields so address comes earlier
- fix dataframe column order when processing resumes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'google')*

------
https://chatgpt.com/codex/tasks/task_e_68522de69f24832492904b72e0a5caa3