### PR TITLE
Implement scan mode toggle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,7 @@ EMAIL_HOST=imap.gmail.com      # server IMAP
 EMAIL_PORT=993                 # cổng IMAP SSL
 EMAIL_USER=                    # email đăng nhập IMAP
 EMAIL_PASS=                    # mật khẩu hoặc app-password
+EMAIL_UNSEEN_ONLY=1           # 1: chỉ quét UNSEEN, 0: quét tất cả
 
 
 # Thư mục lưu attachments và file xuất

--- a/cli_agent.py
+++ b/cli_agent.py
@@ -21,19 +21,21 @@ def cli():
 @click.option('--port', default=lambda: settings.email_port, type=int, help='IMAP port')
 @click.option('--user', default=lambda: settings.email_user, help='Email user')
 @click.option('--password', default=lambda: settings.email_pass, help='Email password')
-def watch(interval, host, port, user, password):
+@click.option('--unseen/--all', 'unseen_only', default=settings.email_unseen_only, show_default=True, help='Chỉ quét email chưa đọc')
+def watch(interval, host, port, user, password, unseen_only):
     """Tự động fetch CV từ email liên tục"""
     click.echo(f"Bắt đầu auto fetch với interval={interval}s...")
-    watch_loop(interval, host=host, port=port, user=user, password=password)
+    watch_loop(interval, host=host, port=port, user=user, password=password, unseen_only=unseen_only)
 
 @cli.command()
-def full_process():
+@click.option('--unseen/--all', 'unseen_only', default=settings.email_unseen_only, show_default=True, help='Chỉ quét email chưa đọc')
+def full_process(unseen_only):
     """Chạy đầy đủ quy trình fetch và xử lý CV"""
     click.echo("Bắt đầu full process...")
     # Fetch email
     fetcher = EmailFetcher(settings.email_host, settings.email_port, settings.email_user, settings.email_pass)
     fetcher.connect()
-    fetcher.fetch_cv_attachments()
+    fetcher.fetch_cv_attachments(unseen_only=unseen_only)
     # Process CVs
     processor = CVProcessor(fetcher)
     df = processor.process()

--- a/main_engine/app.py
+++ b/main_engine/app.py
@@ -26,6 +26,7 @@ from modules.config import (
     EMAIL_PORT,
     EMAIL_USER,
     EMAIL_PASS,
+    EMAIL_UNSEEN_ONLY,
 )
 from modules.email_fetcher import EmailFetcher
 from modules.cv_processor import CVProcessor
@@ -124,6 +125,11 @@ email_pass = st.sidebar.text_input(
     value=st.session_state.get("email_pass", EMAIL_PASS),
     key="email_pass",
 )
+unseen_only = st.sidebar.checkbox(
+    "Chỉ quét email chưa đọc",
+    value=st.session_state.get("unseen_only", EMAIL_UNSEEN_ONLY),
+    key="unseen_only",
+)
 
 # Tự động khởi động auto fetcher khi đã nhập đủ thông tin
 if email_user and email_pass and "auto_fetcher_thread" not in st.session_state:
@@ -136,6 +142,7 @@ if email_user and email_pass and "auto_fetcher_thread" not in st.session_state:
             port=EMAIL_PORT,
             user=email_user,
             password=email_pass,
+            unseen_only=unseen_only,
         )
 
     t = threading.Thread(target=_auto_fetch, daemon=True)
@@ -164,7 +171,7 @@ with tab_fetch:
                 EMAIL_HOST, EMAIL_PORT, email_user, email_pass
             )
             fetcher.connect()
-            new_files = fetcher.fetch_cv_attachments()
+            new_files = fetcher.fetch_cv_attachments(unseen_only=unseen_only)
             if new_files:
                 st.success(f"Đã tải {len(new_files)} file mới:")
                 st.write(new_files)

--- a/modules/auto_fetcher.py
+++ b/modules/auto_fetcher.py
@@ -6,6 +6,8 @@ import logging
 import argparse
 import imaplib
 
+from .config import EMAIL_UNSEEN_ONLY
+
 from .email_fetcher import EmailFetcher
 
 
@@ -15,6 +17,7 @@ def watch_loop(
     port: int | None = None,
     user: str | None = None,
     password: str | None = None,
+    unseen_only: bool = EMAIL_UNSEEN_ONLY,
 ) -> None:
     """Kết nối IMAP và gọi fetch_cv_attachments() liên tục."""
     fetcher = EmailFetcher(host, port, user, password)
@@ -24,7 +27,7 @@ def watch_loop(
     try:
         while True:
             try:
-                fetcher.fetch_cv_attachments()
+                fetcher.fetch_cv_attachments(unseen_only=unseen_only)
             except imaplib.IMAP4.abort:
                 logging.warning("Mất kết nối IMAP, thử kết nối lại...")
                 try:
@@ -56,6 +59,11 @@ def main():
     parser.add_argument("--port", type=int)
     parser.add_argument("--user")
     parser.add_argument("--password")
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Quét tất cả email thay vì chỉ UNSEEN",
+    )
     args = parser.parse_args()
     watch_loop(
         args.interval,
@@ -63,6 +71,7 @@ def main():
         port=args.port,
         user=args.user,
         password=args.password,
+        unseen_only=not args.all,
     )
 
 

--- a/modules/config.py
+++ b/modules/config.py
@@ -53,6 +53,16 @@ else:
 EMAIL_USER = _get_env("EMAIL_USER")
 EMAIL_PASS = _get_env("EMAIL_PASS")
 
+# --- Tuỳ chọn quét email: chỉ UNSEEN hay tất cả ---
+def _get_bool(varname: str, default: bool = True) -> bool:
+    val = os.getenv(varname)
+    if val is None:
+        return default
+    cleaned = val.split('#', 1)[0].strip().lower()
+    return cleaned not in ("0", "false", "no", "")
+
+EMAIL_UNSEEN_ONLY = _get_bool("EMAIL_UNSEEN_ONLY", True)
+
 # --- Thư mục lưu file đính kèm và file xuất kết quả ---
 def _clean_path(varname: str, default: str) -> Path:
     """

--- a/modules/mcp_server.py
+++ b/modules/mcp_server.py
@@ -30,6 +30,7 @@ class Settings(BaseSettings):
     email_pass: str        # mật khẩu/app-password email
     attachment_dir: Path   # thư mục lưu tệp đính kèm
     output_csv: Path       # đường dẫn file CSV xuất kết quả
+    email_unseen_only: bool = True  # chỉ quét email chưa đọc nếu True
 
 
 # Khởi tạo cấu hình từ biến môi trường

--- a/readme.md
+++ b/readme.md
@@ -68,8 +68,9 @@ HoanCau AI Resume Processor là hệ thống tự động trích xuất thông t
    # Email IMAP
    EMAIL_HOST=imap.gmail.com
    EMAIL_PORT=993
-   EMAIL_USER=<YOUR_EMAIL>
-   EMAIL_PASS=<YOUR_PASSWORD>
+  EMAIL_USER=<YOUR_EMAIL>
+  EMAIL_PASS=<YOUR_PASSWORD>
+  EMAIL_UNSEEN_ONLY=1
 
    # Đường dẫn lưu trữ
    ATTACHMENT_DIR=attachments
@@ -85,10 +86,12 @@ Các lệnh chính:
 python3 cli_agent.py --help
 
 # Tự động fetch CV từ email (watch loop)
-python3 cli_agent.py watch --interval 600
+python3 cli_agent.py watch --interval 600     # chỉ quét UNSEEN
+python3 cli_agent.py watch --all             # quét toàn bộ email
 
 # Chạy full process: fetch + xử lý batch
-python3 cli_agent.py full-process
+python3 cli_agent.py full-process            # chỉ quét UNSEEN
+python3 cli_agent.py full-process --all      # quét toàn bộ
 
 # Xử lý một file CV đơn lẻ
 python3 cli_agent.py single path/to/cv.pdf


### PR DESCRIPTION
## Summary
- introduce `EMAIL_UNSEEN_ONLY` option in config and `.env.example`
- default `EmailFetcher.fetch_cv_attachments` to this setting
- pass scan mode through `auto_fetcher`, CLI, and Streamlit UI
- document `--all` usage and new env var

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685236c8f344832487fa3f9946c0da65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an option to filter email fetching to only unread emails, configurable via a sidebar checkbox in the app and a command-line flag.
  - Introduced a new environment variable and configuration setting to control whether only unseen emails are scanned by default.

- **Documentation**
  - Updated documentation and configuration examples to explain the new option for scanning only unseen emails and how to use the related command-line flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->