### PR TITLE
Fix module imports in tabs

### DIFF
--- a/main_engine/tabs/chat_tab.py
+++ b/main_engine/tabs/chat_tab.py
@@ -4,8 +4,8 @@ import pandas as pd
 import streamlit as st
 from typing import cast
 
-from ..modules.qa_chatbot import answer_question
-from ..modules.config import OUTPUT_CSV
+from modules.qa_chatbot import answer_question
+from modules.config import OUTPUT_CSV
 
 
 def render(provider: str, model: str, api_key: str) -> None:

--- a/main_engine/tabs/fetch_tab.py
+++ b/main_engine/tabs/fetch_tab.py
@@ -3,8 +3,8 @@ import os
 from typing import List
 import streamlit as st
 
-from ..modules.config import ATTACHMENT_DIR, EMAIL_HOST, EMAIL_PORT
-from ..modules.email_fetcher import EmailFetcher
+from modules.config import ATTACHMENT_DIR, EMAIL_HOST, EMAIL_PORT
+from modules.email_fetcher import EmailFetcher
 
 
 def render(email_user: str, email_pass: str, unseen_only: bool) -> None:

--- a/main_engine/tabs/mcp_tab.py
+++ b/main_engine/tabs/mcp_tab.py
@@ -3,7 +3,7 @@ import os
 import subprocess
 import streamlit as st
 
-from ..modules.config import MCP_API_KEY
+from modules.config import MCP_API_KEY
 
 
 def render(detect_platform) -> None:

--- a/main_engine/tabs/process_tab.py
+++ b/main_engine/tabs/process_tab.py
@@ -3,8 +3,8 @@ import os
 import pandas as pd
 import streamlit as st
 
-from ..modules.cv_processor import CVProcessor
-from ..modules.config import ATTACHMENT_DIR, OUTPUT_CSV, get_model_price
+from modules.cv_processor import CVProcessor
+from modules.config import ATTACHMENT_DIR, OUTPUT_CSV, get_model_price
 
 
 def render(provider: str, model: str, api_key: str) -> None:

--- a/main_engine/tabs/results_tab.py
+++ b/main_engine/tabs/results_tab.py
@@ -2,7 +2,7 @@ import os
 import pandas as pd
 import streamlit as st
 
-from ..modules.config import OUTPUT_CSV
+from modules.config import OUTPUT_CSV
 
 
 def render() -> None:

--- a/main_engine/tabs/single_tab.py
+++ b/main_engine/tabs/single_tab.py
@@ -3,8 +3,8 @@ from pathlib import Path
 import streamlit as st
 import pandas as pd
 
-from ..modules.cv_processor import CVProcessor
-from ..modules.config import get_model_price
+from modules.cv_processor import CVProcessor
+from modules.config import get_model_price
 
 
 def render(provider: str, model: str, api_key: str, root: Path) -> None:


### PR DESCRIPTION
## Summary
- reference core modules via absolute imports

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'google')*

------
https://chatgpt.com/codex/tasks/task_e_6853772173c08324b3e96018646ad3bd