### PR TITLE
Add missing __init__ file for modules package

### DIFF
--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,0 +1,1 @@
+"""Utility package for HoanCau AI modules."""

--- a/modules/mcp_server.py
+++ b/modules/mcp_server.py
@@ -10,8 +10,8 @@ from fastapi.responses import FileResponse    # trả về file như response
 from pydantic_settings import BaseSettings, SettingsConfigDict      # sử dụng BaseSettings với cấu hình cho Pydantic v2
 
 
-from modules.cv_processor import CVProcessor    # lớp xử lý CV thành DataFrame
-from modules.email_fetcher import EmailFetcher  # lớp fetch email và tải đính kèm
+from .cv_processor import CVProcessor    # lớp xử lý CV thành DataFrame
+from .email_fetcher import EmailFetcher  # lớp fetch email và tải đính kèm
 
 
 class Settings(BaseSettings):


### PR DESCRIPTION
## Summary
- make `modules` a Python package
- use relative imports in `mcp_server`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68537911c4b083249af61cbdd9c3f6ff