### PR TITLE
Fix chat command to read API key from config

### DIFF
--- a/cli_agent.py
+++ b/cli_agent.py
@@ -3,6 +3,7 @@ import threading
 import click
 import pandas as pd
 import uvicorn
+from modules.config import LLM_CONFIG
 
 from modules.auto_fetcher import watch_loop
 from modules.email_fetcher import EmailFetcher
@@ -74,7 +75,7 @@ def chat(question):
     # Chọn provider và model từ env hoặc default
     provider = os.getenv('LLM_PROVIDER', 'google')
     model = os.getenv('LLM_MODEL', '')
-    api_key = os.getenv('LLM_API_KEY', '')
+    api_key = LLM_CONFIG.get('api_key', '')
     answer = answer_question(question, df, provider, model, api_key)
     click.echo(answer)
 

--- a/readme.md
+++ b/readme.md
@@ -113,6 +113,8 @@ python3 cli_agent.py serve --host 0.0.0.0 --port 8000
 # Hỏi AI dựa trên kết quả CSV
 python3 cli_agent.py chat "Câu hỏi của bạn"
 ```
+Lệnh `chat` tự động sử dụng khóa API tương ứng với `LLM_PROVIDER`
+được khai báo trong file `.env` (`GOOGLE_API_KEY` hoặc `OPENROUTER_API_KEY`).
 
 ## 🌐 Giao diện web (Streamlit)
 


### PR DESCRIPTION
## Summary
- import `LLM_CONFIG` in `cli_agent`
- use configured API key for the `chat` command
- document how the chat command reads provider-specific API keys

## Testing
- `python3 cli_agent.py chat "Hello"` *(fails: GOOGLE_API_KEY missing)*

------
https://chatgpt.com/codex/tasks/task_e_68537bab9a2883248841a6a1c2483cb0