### PR TITLE
Inject LLM client into CVProcessor

### DIFF
--- a/cli_agent.py
+++ b/cli_agent.py
@@ -8,6 +8,7 @@ from modules.config import LLM_CONFIG
 from modules.auto_fetcher import watch_loop
 from modules.email_fetcher import EmailFetcher
 from modules.cv_processor import CVProcessor
+from modules.llm_client import LLMClient
 from modules.qa_chatbot import answer_question
 from modules.mcp_server import settings
 
@@ -38,7 +39,7 @@ def full_process(unseen_only):
     fetcher.connect()
     fetcher.fetch_cv_attachments(unseen_only=unseen_only)
     # Process CVs
-    processor = CVProcessor(fetcher)
+    processor = CVProcessor(fetcher, llm_client=LLMClient())
     df = processor.process()
     if df.empty:
         click.echo("Không có CV mới để xử lý.")
@@ -51,7 +52,7 @@ def full_process(unseen_only):
 def single(file):
     """Xử lý một file CV đơn lẻ"""
     click.echo(f"Xử lý file: {file}")
-    processor = CVProcessor()
+    processor = CVProcessor(llm_client=LLMClient())
     text = processor.extract_text(file)
     info = processor.extract_info_with_llm(text)
     click.echo(info)

--- a/main_engine/main.py
+++ b/main_engine/main.py
@@ -46,8 +46,7 @@ def main(batch: bool, watch: bool, interval: int, file):
             return
         fetcher = EmailFetcher(EMAIL_HOST, EMAIL_PORT, EMAIL_USER, EMAIL_PASS)
         fetcher.connect()
-        processor = CVProcessor(fetcher)
-        processor.llm_client = llm_client    # gán client
+        processor = CVProcessor(fetcher, llm_client=llm_client)
         df = processor.process()
         if not df.empty:
             processor.save_to_csv(df, OUTPUT_CSV)
@@ -59,8 +58,7 @@ def main(batch: bool, watch: bool, interval: int, file):
         if not file:
             click.echo("Vui lòng cung cấp đường dẫn file khi dùng --single")
             return
-        processor = CVProcessor()
-        processor.llm_client = llm_client
+        processor = CVProcessor(llm_client=llm_client)
         text = processor.extract_text(file)
         info = processor.extract_info_with_llm(text)
         click.echo(info)

--- a/main_engine/tabs/process_tab.py
+++ b/main_engine/tabs/process_tab.py
@@ -5,6 +5,7 @@ import streamlit as st
 
 from modules.cv_processor import CVProcessor
 from modules.config import ATTACHMENT_DIR, OUTPUT_CSV, get_model_price
+from modules.dynamic_llm_client import DynamicLLMClient
 
 
 def render(provider: str, model: str, api_key: str) -> None:
@@ -19,10 +20,13 @@ def render(provider: str, model: str, api_key: str) -> None:
         if not files:
             st.warning("Không có file CV trong thư mục attachments để xử lý.")
         else:
-            processor = CVProcessor()
-            processor.llm_client.provider = provider
-            processor.llm_client.model = model
-            processor.llm_client.api_key = api_key
+            processor = CVProcessor(
+                llm_client=DynamicLLMClient(
+                    provider=provider,
+                    model=model,
+                    api_key=api_key,
+                )
+            )
             progress = st.progress(0)
             status = st.empty()
             results = []

--- a/main_engine/tabs/single_tab.py
+++ b/main_engine/tabs/single_tab.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 from modules.cv_processor import CVProcessor
 from modules.config import get_model_price
+from modules.dynamic_llm_client import DynamicLLMClient
 
 
 def render(provider: str, model: str, api_key: str, root: Path) -> None:
@@ -19,10 +20,13 @@ def render(provider: str, model: str, api_key: str, root: Path) -> None:
         tmp_file.write_bytes(uploaded.getbuffer())
         with st.spinner(f"Đang trích xuất & phân tích... (LLM: {provider}/{label})"):
             logging.info(f"Xử lý file đơn {uploaded.name}")
-            proc = CVProcessor()
-            proc.llm_client.provider = provider
-            proc.llm_client.model = model
-            proc.llm_client.api_key = api_key
+            proc = CVProcessor(
+                llm_client=DynamicLLMClient(
+                    provider=provider,
+                    model=model,
+                    api_key=api_key,
+                )
+            )
             text = proc.extract_text(str(tmp_file))
             info = proc.extract_info_with_llm(text)
         st.json(info)

--- a/modules/cv_processor.py
+++ b/modules/cv_processor.py
@@ -40,7 +40,7 @@ except ImportError:
         except ImportError:
             _PDF_EX = None  # không có thư viện PDF nào
 
-from .dynamic_llm_client import DynamicLLMClient  # client gọi LLM động
+from .llm_client import LLMClient  # client LLM mặc định
 from .config import ATTACHMENT_DIR, OUTPUT_CSV  # cấu hình thư mục và file xuất
 from .prompts import CV_EXTRACTION_PROMPT  # prompt LLM để trích xuất CV
 
@@ -48,10 +48,10 @@ class CVProcessor:
     """
     Lớp xử lý file CV: đọc text, gọi LLM hoặc regex fallback, trả về DataFrame
     """
-    def __init__(self, fetcher: Optional[object] = None):
-        """Khởi tạo: cấp fetcher (đọc email), khởi tạo LLM client"""
+    def __init__(self, fetcher: Optional[object] = None, llm_client: Optional[LLMClient] = None):
+        """Khởi tạo: cấp fetcher (đọc email) và LLM client"""
         self.fetcher = fetcher  # đối tượng có method fetch_cv_attachments()
-        self.llm_client = DynamicLLMClient()  # khởi tạo client gọi LLM
+        self.llm_client = llm_client or LLMClient()  # client LLM mặc định
 
     def _extract_pdf(self, path: str) -> str:
         """

--- a/modules/mcp_server.py
+++ b/modules/mcp_server.py
@@ -12,6 +12,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict      # sử dụn
 
 from .cv_processor import CVProcessor    # lớp xử lý CV thành DataFrame
 from .email_fetcher import EmailFetcher  # lớp fetch email và tải đính kèm
+from .llm_client import LLMClient
 
 
 class Settings(BaseSettings):
@@ -85,7 +86,7 @@ async def run_full():
     fetcher.connect()
 
     # Xử lý CV từ fetcher
-    processor = CVProcessor(fetcher)
+    processor = CVProcessor(fetcher, llm_client=LLMClient())
     df = processor.process()
 
     # Nếu không có CV mới, trả về số bản ghi đã xử lý = 0
@@ -114,7 +115,7 @@ async def process_single_cv(file: UploadFile = File(...)):
         shutil.copyfileobj(file.file, buffer)
 
     # Trích xuất text và thông tin
-    processor = CVProcessor()
+    processor = CVProcessor(llm_client=LLMClient())
     text = processor.extract_text(str(tmp_path))
 
     # Xóa file tạm (nếu có lỗi, chỉ log warning)


### PR DESCRIPTION
## Summary
- allow `CVProcessor` to accept an optional LLM client
- explicitly pass an LLM client from CLI and FastAPI server
- construct dynamic clients for Streamlit tabs
- wire up main CLI to use the new constructor

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853801a6a6083249c87a92eda6272b2