### PR TITLE
Add tests for CV regex and email attachments

### DIFF
--- a/test_cv_processor.py
+++ b/test_cv_processor.py
@@ -1,0 +1,63 @@
+import sys
+import types
+import pytest
+
+# Stub external dependencies before importing cv_processor
+class DummyStreamlit:
+    session_state = {}
+
+class DummyGenAI:
+    def configure(self, **kw):
+        pass
+    class GenerativeModel:
+        def __init__(self, model):
+            self.model = model
+        def generate_content(self, prompt):
+            return types.SimpleNamespace(text="")
+    def list_models(self):
+        return []
+
+sys.modules.setdefault('streamlit', DummyStreamlit())
+sys.modules.setdefault('google', types.SimpleNamespace(generativeai=DummyGenAI()))
+sys.modules.setdefault('google.generativeai', DummyGenAI())
+
+import modules.cv_processor as cvp
+
+# Replace DynamicLLMClient with dummy to avoid API requirements
+class DummyLLMClient:
+    def generate_content(self, messages):
+        return ''
+
+cvp.DynamicLLMClient = DummyLLMClient
+CVProcessor = cvp.CVProcessor
+
+
+@pytest.mark.parametrize('text,expected', [
+    (
+        """Họ tên: Nguyen Van A\nEmail: a@test.com\nĐiện thoại: +84987654321\nĐịa chỉ: 123 Street\nHọc vấn: University ABC\nKinh nghiệm: 5 năm\nKỹ năng: Python""",
+        {
+            'ten': 'Nguyen Van A',
+            'email': 'a@test.com',
+            'dien_thoai': '+84987654321',
+            'hoc_van': 'University ABC',
+            'kinh_nghiem': '5 năm',
+            'dia_chi': '123 Street',
+            'ky_nang': 'Python',
+        }
+    ),
+    (
+        """Họ tên: John Smith\nEmail: john@example.com\nĐiện thoại: 555-123-4567\nAddress: 1 Main St\nEducation: BSc\nExperience: 3 years\nSkills: Java""",
+        {
+            'ten': 'John Smith',
+            'email': 'john@example.com',
+            'dien_thoai': '555-123-4567',
+            'hoc_van': 'BSc',
+            'kinh_nghiem': '3 years',
+            'dia_chi': '1 Main St',
+            'ky_nang': 'Java',
+        }
+    )
+])
+def test_fallback_regex(text, expected):
+    info = CVProcessor()._fallback_regex(text)
+    assert info == expected

--- a/test_email_fetcher.py
+++ b/test_email_fetcher.py
@@ -1,0 +1,53 @@
+import sys
+import types
+from email.message import EmailMessage
+from pathlib import Path
+import importlib
+import pytest
+
+
+class DummyGenAI:
+    def configure(self, **kwargs):
+        pass
+
+    def list_models(self):
+        return []
+
+
+@pytest.fixture
+def email_fetcher_module(monkeypatch, tmp_path):
+    fake = DummyGenAI()
+    sys.modules['google'] = types.SimpleNamespace(generativeai=fake)
+    sys.modules['google.generativeai'] = fake
+    import modules.email_fetcher as email_fetcher
+    importlib.reload(email_fetcher)
+    monkeypatch.setattr(email_fetcher, 'ATTACHMENT_DIR', tmp_path)
+    return email_fetcher
+
+
+def test_fetch_cv_attachments(email_fetcher_module, tmp_path):
+    email_fetcher = email_fetcher_module
+    EmailFetcher = email_fetcher.EmailFetcher
+
+    msg = EmailMessage()
+    msg['Subject'] = 'CV Nguyen'
+    msg.set_content('body')
+    msg.add_attachment(b'data', maintype='application', subtype='pdf', filename='cv.pdf')
+    raw = msg.as_bytes()
+
+    class FakeIMAP:
+        def search(self, charset, *criteria):
+            return 'OK', [b'1']
+
+        def fetch(self, num, query):
+            return 'OK', [(None, raw)]
+
+        def store(self, *args, **kwargs):
+            pass
+
+    fetcher = EmailFetcher()
+    fetcher.mail = FakeIMAP()
+    files = fetcher.fetch_cv_attachments()
+    expected = tmp_path / 'cv.pdf'
+    assert files == [str(expected)]
+    assert expected.exists()


### PR DESCRIPTION
## Summary
- test `_fallback_regex` with Vietnamese and English samples
- test `EmailFetcher.fetch_cv_attachments` using a mock IMAP implementation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853801c98d883249d677522c1dfff20