### PR TITLE
Analyze entire dataset in qa_chatbot

### DIFF
--- a/modules/qa_chatbot.py
+++ b/modules/qa_chatbot.py
@@ -7,10 +7,10 @@ def answer_question(question: str, df: pd.DataFrame, provider: str, model: str, 
     if df is None or df.empty:
         raise ValueError("Dataset trống")
 
-    preview = df.head(20).to_csv(index=False)
+    preview = df.to_csv(index=False)
     messages = [
         "Bạn là trợ lý AI phân tích dữ liệu CV từ file CSV.",
-        "Dưới đây là 20 dòng đầu tiên của dữ liệu:\n" + preview,
+        "Dưới đây là toàn bộ dữ liệu:\n" + preview,
         f"Câu hỏi: {question}"
     ]
     client = DynamicLLMClient(provider=provider, model=model, api_key=api_key)


### PR DESCRIPTION
## Summary
- update `qa_chatbot.answer_question` to pass the entire dataset for AI analysis

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'google')*

------
https://chatgpt.com/codex/tasks/task_e_68538055e9f483248e749c4ce7618079