### PR TITLE
Configure OpenRouter base URL via env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,7 @@ LLM_MODEL=gemini-2.0-flash  # model mặc định
 # Khóa API
 GOOGLE_API_KEY=your_google_api_key
 OPENROUTER_API_KEY=your_openrouter_api_key
+OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
 MCP_API_KEY=your_mcp_api_key
 
 # Cấu hình IMAP để fetch CV

--- a/modules/config.py
+++ b/modules/config.py
@@ -36,8 +36,11 @@ OPENROUTER_API_KEY = _get_env("OPENROUTER_API_KEY")
 MCP_API_KEY = _get_env("MCP_API_KEY")  # API key dùng cho MCP server (tự nhận diện)
 
 # --- Base URL cho OpenRouter API ---
+# Có thể tuỳ chỉnh qua biến môi trường OPENROUTER_BASE_URL
 # Dùng chung cho mọi client và fetcher
-OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+OPENROUTER_BASE_URL = _get_env(
+    "OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1"
+)
 
 # --- Cấu hình email (không bắt buộc) ---
 EMAIL_HOST = _get_env("EMAIL_HOST", "imap.gmail.com")

--- a/readme.md
+++ b/readme.md
@@ -62,7 +62,8 @@ HoanCau AI Resume Processor là hệ thống tự động trích xuất thông t
    cp .env.example .env
    ```
    Sau đó mở `.env` và thay thế các giá trị placeholder (như `your_google_api_key`)
-   bằng thông tin thực tế.
+   bằng thông tin thực tế. Nếu sử dụng OpenRouter qua proxy, có thể sửa
+   `OPENROUTER_BASE_URL` để trỏ tới endpoint mong muốn.
 
 ### 💻 Cài đặt nhanh trên Windows
 


### PR DESCRIPTION
## Summary
- make `OPENROUTER_BASE_URL` configurable via env variable
- document new variable in README and `.env.example`

## Testing
- `pip install google-generativeai`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853801bcc2c83249a04853ba6d63260