### PR TITLE
Add chat conversation logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,6 +77,7 @@ TEMP_DIR=./temp               # Thư mục tạm
 OUTPUT_CSV=cv_analysis.csv     # File CSV tổng hợp
 OUTPUT_JSON=cv_analysis.json   # File JSON chi tiết
 OUTPUT_EXCEL=cv_analysis.xlsx  # File Excel báo cáo
+CHAT_LOG_FILE=./chat_logs/chat_log.json  # Log cuộc trò chuyện
 
 # =======================================================================
 # 🚨 SECURITY & LOGGING

--- a/modules/config.py
+++ b/modules/config.py
@@ -80,8 +80,11 @@ def _clean_path(varname: str, default: str) -> Path:
 
 ATTACHMENT_DIR = _clean_path("ATTACHMENT_DIR", "attachments")
 OUTPUT_CSV = _clean_path("OUTPUT_CSV", "cv_summary.csv")
+# File lưu log hội thoại chat
+CHAT_LOG_FILE = _clean_path("CHAT_LOG_FILE", "chat_logs/chat_log.json")
 # tạo thư mục nếu chưa tồn tại
 ATTACHMENT_DIR.mkdir(parents=True, exist_ok=True)
+CHAT_LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
 
 # --- Danh sách models dự phòng ---
 GOOGLE_FALLBACK_MODELS: List[str] = [

--- a/modules/qa_chatbot.py
+++ b/modules/qa_chatbot.py
@@ -1,5 +1,30 @@
+import json
+import logging
+from datetime import datetime
 import pandas as pd
+from pathlib import Path
 from .dynamic_llm_client import DynamicLLMClient
+from .config import CHAT_LOG_FILE
+
+
+def _log_chat(question: str, answer: str, log_file: Path = CHAT_LOG_FILE) -> None:
+    """Append a Q&A pair to the chat log file in JSON format."""
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "question": question,
+        "answer": answer,
+    }
+    try:
+        if log_file.exists():
+            with open(log_file, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        else:
+            data = []
+        data.append(entry)
+        with open(log_file, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+    except Exception as e:
+        logging.warning(f"Không thể ghi log chat: {e}")
 
 
 def answer_question(question: str, df: pd.DataFrame, provider: str, model: str, api_key: str) -> str:
@@ -14,5 +39,7 @@ def answer_question(question: str, df: pd.DataFrame, provider: str, model: str, 
         f"Câu hỏi: {question}"
     ]
     client = DynamicLLMClient(provider=provider, model=model, api_key=api_key)
-    return client.generate_content(messages)
+    answer = client.generate_content(messages)
+    _log_chat(question, answer)
+    return answer
 

--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,7 @@ HoanCau AI Resume Processor là hệ thống tự động trích xuất thông t
 - Xử lý một file CV đơn lẻ.
 - Chạy lệnh CLI, web UI hoặc FastAPI server.
 - Hỏi AI (chat) dựa trên dữ liệu đã xử lý.
+- Lưu log cuộc trò chuyện của tính năng Hỏi AI.
 - Không gây cảnh báo Streamlit khi chạy CLI: `DynamicLLMClient` tự kiểm tra session context.
 
 ## 🚀 Bắt đầu nhanh
@@ -117,6 +118,7 @@ python3 cli_agent.py chat "Câu hỏi của bạn"
 ```
 Lệnh `chat` tự động sử dụng khóa API tương ứng với `LLM_PROVIDER`
 được khai báo trong file `.env` (`GOOGLE_API_KEY` hoặc `OPENROUTER_API_KEY`).
+Mỗi lần hỏi đáp sẽ được lưu vào file log tại `chat_logs/chat_log.json` (có thể thay đổi qua biến `CHAT_LOG_FILE`).
 
 ## 🌐 Giao diện web (Streamlit)
 


### PR DESCRIPTION
## Summary
- add `CHAT_LOG_FILE` configuration and auto-create directory
- implement chat logging in `qa_chatbot`
- update docs and `.env.example` with chat log info

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685390b1826c8324be491b39192747e8