### PR TITLE
Automate CV email fetching and processing

### DIFF
--- a/modules/auto_fetcher.py
+++ b/modules/auto_fetcher.py
@@ -6,9 +6,11 @@ import logging
 import argparse
 import imaplib
 
-from .config import EMAIL_UNSEEN_ONLY
+from .config import EMAIL_UNSEEN_ONLY, OUTPUT_CSV
 
 from .email_fetcher import EmailFetcher
+from .cv_processor import CVProcessor
+from .llm_client import LLMClient
 
 
 def watch_loop(
@@ -19,15 +21,20 @@ def watch_loop(
     password: str | None = None,
     unseen_only: bool = EMAIL_UNSEEN_ONLY,
 ) -> None:
-    """Kết nối IMAP và gọi fetch_cv_attachments() liên tục."""
+    """Kết nối IMAP, fetch và xử lý CV liên tục."""
     fetcher = EmailFetcher(host, port, user, password)
+    processor = CVProcessor(fetcher, llm_client=LLMClient())
     fetcher.connect()
     logging.info(f"Bắt đầu auto fetch, interval={interval}s")
 
     try:
         while True:
             try:
-                fetcher.fetch_cv_attachments(unseen_only=unseen_only)
+                files = fetcher.fetch_cv_attachments(unseen_only=unseen_only)
+                for path in files:
+                    df = processor.process_file(path)
+                    if not df.empty:
+                        processor.save_to_csv(df, str(OUTPUT_CSV), append=True)
             except imaplib.IMAP4.abort:
                 logging.warning("Mất kết nối IMAP, thử kết nối lại...")
                 try:

--- a/modules/cv_processor.py
+++ b/modules/cv_processor.py
@@ -151,6 +151,33 @@ class CVProcessor:
             info[k] = m.group(1).strip() if m else ""
         return info
 
+    def process_file(self, path: str) -> pd.DataFrame:
+        """Xử lý một file CV đơn lẻ và trả về DataFrame 1 dòng."""
+        txt = self.extract_text(path)
+        info = self.extract_info_with_llm(txt) or {}
+        row = {
+            "Nguồn": os.path.basename(path),
+            "Họ tên": info.get("ten", ""),
+            "Tuổi": info.get("tuoi", ""),
+            "Email": info.get("email", ""),
+            "Điện thoại": info.get("dien_thoai", ""),
+            "Địa chỉ": info.get("dia_chi", ""),
+            "Học vấn": info.get("hoc_van", ""),
+            "Kinh nghiệm": info.get("kinh_nghiem", ""),
+            "Kỹ năng": info.get("ky_nang", ""),
+        }
+        return pd.DataFrame([row], columns=[
+            "Nguồn",
+            "Họ tên",
+            "Tuổi",
+            "Email",
+            "Điện thoại",
+            "Địa chỉ",
+            "Học vấn",
+            "Kinh nghiệm",
+            "Kỹ năng",
+        ])
+
     def process(self) -> pd.DataFrame:
         """
         Tìm tất cả file CV (fetcher hoặc thư mục attachments), trích xuất info, trả về DataFrame
@@ -198,9 +225,10 @@ class CVProcessor:
         ])  # tạo DataFrame từ list dict với thứ tự cột cố định
         return df  # trả về kết quả
 
-    def save_to_csv(self, df: pd.DataFrame, output: str = OUTPUT_CSV):
-        """
-        Ghi đè file CSV mỗi lần chạy; nếu muốn append, có thể chuyển mode và header
-        """
-        df.to_csv(output, index=False, encoding="utf-8-sig")  # lưu file
+    def save_to_csv(self, df: pd.DataFrame, output: str = OUTPUT_CSV, append: bool = False):
+        """Lưu DataFrame vào CSV. Nếu append=True thì nối thêm."""
+        if append and os.path.exists(output):
+            df.to_csv(output, mode="a", header=False, index=False, encoding="utf-8-sig")
+        else:
+            df.to_csv(output, index=False, encoding="utf-8-sig")
         logger.info(f"✅ Đã lưu {len(df)} hồ sơ vào {output}")

--- a/modules/email_fetcher.py
+++ b/modules/email_fetcher.py
@@ -143,6 +143,8 @@ class EmailFetcher:
                     name, ext = os.path.splitext(filename)
                     if ext.lower() not in ['.pdf', '.docx']:
                         continue
+                    if not re.search(r"\b(cv|resume|curriculum vitae)\b", name, re.I):
+                        continue
                     safe_name = re.sub(r'[^\w\-\_ ]', '_', name)
                     safe = safe_name + ext
 

--- a/test/test_email_fetcher.py
+++ b/test/test_email_fetcher.py
@@ -54,3 +54,29 @@ def test_fetch_cv_attachments(email_fetcher_module, tmp_path):
     expected = tmp_path / 'cv.pdf'
     assert files == [str(expected)]
     assert expected.exists()
+
+
+def test_ignore_non_cv_files(email_fetcher_module, tmp_path):
+    email_fetcher = email_fetcher_module
+    EmailFetcher = email_fetcher.EmailFetcher
+
+    msg = EmailMessage()
+    msg['Subject'] = 'CV Nguyen'
+    msg.set_content('body')
+    msg.add_attachment(b'data', maintype='application', subtype='pdf', filename='invoice.pdf')
+    raw = msg.as_bytes()
+
+    class FakeIMAP:
+        def search(self, charset, *criteria):
+            return 'OK', [b'1']
+
+        def fetch(self, num, query):
+            return 'OK', [(None, raw)]
+
+        def store(self, *args, **kwargs):
+            pass
+
+    fetcher = EmailFetcher()
+    fetcher.mail = FakeIMAP()
+    files = fetcher.fetch_cv_attachments()
+    assert files == []


### PR DESCRIPTION
## Summary
- filter email attachments by CV keywords in the filename
- append results when saving to CSV
- add helper to process a single CV file
- automatically process new CVs in the watch loop
- test skipping non-CV attachments

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853bdd0ed288324aefea3e06c9a0511

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Automatically processes and extracts information from CV attachments in emails, saving results to a CSV file.
- **Bug Fixes**
	- Improved filtering to ensure only attachments explicitly named as CVs or resumes are processed.
- **Tests**
	- Added a test to confirm non-CV attachments are ignored during email processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->