### PR TITLE
Improve setup docs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,23 @@ HoanCau AI Resume Processor là hệ thống tự động trích xuất thông t
 - Tài khoản email IMAP (Gmail, Outlook, v.v.) với quyền truy cập IMAP hiện bật
 - Trình duyệt web hiện đại (Chrome, Firefox) để sử dụng giao diện Streamlit
 
+## 🚦 Beginner Setup
+
+1. **Cài Python và Git**
+   - Tải Python từ [python.org](https://www.python.org/downloads/) rồi cài đặt
+     như hướng dẫn (Windows nhớ tick "Add python to PATH").
+   - Tải Git tại [git-scm.com](https://git-scm.com/downloads) và cài đặt mặc định.
+2. **Mở Terminal / Command Prompt**
+   - **Windows**: nhấn `Win + R` → gõ `cmd` → Enter.
+   - **macOS**: mở **Terminal** từ Spotlight hoặc Applications.
+   - **Linux**: mở ứng dụng **Terminal**.
+3. **Kiểm tra phiên bản**
+   ```bash
+   python --version   # hoặc python3 --version
+   git --version
+   ```
+   Nếu cả hai lệnh đều in phiên bản, bạn đã sẵn sàng tiếp tục.
+
 ## ✉️ Troubleshooting Email Fetch
 
 - Đảm bảo IMAP đã được bật trong cài đặt email (Gmail: Settings → Forwarding and POP/IMAP → Enable IMAP).
@@ -56,6 +73,8 @@ HoanCau AI Resume Processor là hệ thống tự động trích xuất thông t
    pip install --upgrade pip
    pip install -r requirements.txt
    ```
+   Hoặc đơn giản chạy `./setup.sh` (macOS/Linux) hoặc `setup.cmd` (Windows)
+   để tự động thực hiện các bước trên.
 
 3. **Tạo file `.env`**
 
@@ -63,9 +82,14 @@ HoanCau AI Resume Processor là hệ thống tự động trích xuất thông t
    ```bash
    cp .env.example .env
    ```
-   Sau đó mở `.env` và thay thế các giá trị placeholder (như `your_google_api_key`)
-   bằng thông tin thực tế. Nếu sử dụng OpenRouter qua proxy, có thể sửa
-   `OPENROUTER_BASE_URL` để trỏ tới endpoint mong muốn.
+   Sau đó mở `.env` bằng editor bất kỳ và thay thế các giá trị placeholder
+   (như `your_google_api_key`) bằng thông tin thực tế. Những biến quan trọng gồm:
+   `LLM_PROVIDER`, `LLM_MODEL`, một trong các khóa API (`GOOGLE_API_KEY` hoặc
+   `OPENROUTER_API_KEY`), `EMAIL_USER` và `EMAIL_PASS`. File `.env` đã nằm trong
+   `.gitignore` nên **không commit** lên Git. Nếu gặp lỗi cấu hình, hãy so sánh
+   với file mẫu `.env.example`.
+   Bạn có thể tạo sẵn các thư mục `attachments`, `output` và `log` (hoặc để
+   script tự tạo) để lưu file tải về và log.
 
 ### 💻 Cài đặt nhanh trên Windows
 
@@ -78,6 +102,16 @@ HoanCau AI Resume Processor là hệ thống tự động trích xuất thông t
    `EMAIL_*`.
 5. Cuối cùng chạy `run_resume_ai.cmd` để khởi động (không tham số sẽ mở UI,
    thêm `cli` để chạy qua dòng lệnh).
+
+### 📦 Tự động setup trên macOS/Linux
+
+Trong thư mục dự án, chạy:
+
+```bash
+./setup.sh
+```
+
+Script sẽ tạo `.env`, virtualenv và cài dependencies tương tự `setup.cmd`.
 
 ### 🛡️ SmartScreen trên Windows
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -e
+
+GREEN="\033[0;32m"
+RESET="\033[0m"
+
+echo -e "${GREEN}======================================================"
+echo -e "             RESUME AI - SETUP SCRIPT             "
+echo -e "======================================================${RESET}"
+
+# 1) Check Python
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "Python 3 không tìm thấy. Cài Python từ https://www.python.org rồi chạy lại." >&2
+  exit 1
+fi
+
+echo "Đã có Python: $(python3 --version)"
+
+# 2) Copy .env if missing
+if [ ! -f .env ]; then
+  if [ -f .env.example ]; then
+    cp .env.example .env
+    echo "Đã tạo file .env từ .env.example. Vui lòng chỉnh sửa giá trị."
+  else
+    echo "Không tìm thấy .env.example. Hãy tạo file .env thủ công." >&2
+  fi
+else
+  echo "File .env đã tồn tại."
+fi
+
+# 3) Create virtual environment if missing
+if [ ! -d .venv ]; then
+  echo "Tạo virtual environment..."
+  python3 -m venv .venv
+else
+  echo "Virtual environment đã tồn tại."
+fi
+
+# 4) Activate virtualenv
+source .venv/bin/activate
+
+# 5) Install dependencies
+pip install --upgrade pip
+pip install -r requirements.txt
+
+# 6) Create folders
+mkdir -p attachments output log
+
+echo -e "${GREEN}Setup hoàn tất!${RESET}"


### PR DESCRIPTION
## Summary
- add beginner setup guide
- flesh out `.env` instructions
- mention auto-created folders for attachments, output and log
- support macOS/Linux setup via `setup.sh`
- document cross-platform setup scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854e1513c6483249588d35d2585f3d4