### PR TITLE
Add colorful banners for scripts

### DIFF
--- a/run_resume_ai.cmd
+++ b/run_resume_ai.cmd
@@ -1,12 +1,13 @@
 @echo off
 setlocal enableextensions enabledelayedexpansion
 
-:: Hiển thị banner màu cho giao diện dễ nhìn
-color 0A
+:: Hiển thị banner nhiều màu
+color 0E
 cls
-echo ======================================================
-echo                  RESUME AI - KHỞI ĐỘNG
-echo ======================================================
+powershell -NoProfile -Command "Write-Host '=====================================================' -ForegroundColor Cyan"
+powershell -NoProfile -Command "$t='RESUME AI - KHỞI ĐỘNG'; $c=@('Red','Yellow','Green','Cyan','Magenta','Blue','White'); for($i=0;$i -lt $t.Length;$i++){Write-Host -NoNewline $t[$i] -ForegroundColor $c[$i % $c.Count]} ; Write-Host ''"
+powershell -NoProfile -Command "Write-Host '=====================================================' -ForegroundColor Cyan"
+color 07
 :: ======================================================
 :: Resume AI - Entry Script (auto launch Streamlit UI)
 :: ======================================================
@@ -32,6 +33,7 @@ if exist "%~dp0.venv\Scripts\activate.bat" (
 )
 
 :: 3) Loading animation trước khi chạy UI
+color 0A
 set "spin=/ - \ |"
 for /L %%n in (1,1,20) do (
     set /A idx=%%n %% 4
@@ -39,9 +41,10 @@ for /L %%n in (1,1,20) do (
     ping 127.0.0.1 -n 2 > nul
 )
 echo.
+color 07
 
 :: 4) Khởi động Streamlit UI
 streamlit run "%~dp0main_engine\app.py"
 
-echo Ứng dụng đã thoát. Nhấn phím bất kỳ để đóng.
+powershell -NoProfile -Command "Write-Host 'Ứng dụng đã thoát. Nhấn phím bất kỳ để đóng.' -ForegroundColor Yellow"
 pause

--- a/run_resume_ai.sh
+++ b/run_resume_ai.sh
@@ -1,12 +1,18 @@
 #!/usr/bin/env bash
 set -e
 
-GREEN="\033[0;32m"
+YELLOW="\033[1;33m"
+WHITE="\033[1;37m"
+GREEN="\033[0;92m"
 RESET="\033[0m"
 
-echo -e "${GREEN}======================================================"
-echo -e "                RESUME AI - KHỞI ĐỘNG               "
-echo -e "======================================================${RESET}"
+echo -e "${GREEN}======================================================${RESET}"
+if command -v lolcat >/dev/null 2>&1; then
+  echo "                RESUME AI - KHỞI ĐỘNG               " | lolcat
+else
+  echo -e "${YELLOW}                RESUME AI - KHỞI ĐỘNG               ${RESET}"
+fi
+echo -e "${GREEN}======================================================${RESET}"
 
 # 1) Check Python
 if ! command -v python3 >/dev/null 2>&1; then
@@ -29,7 +35,7 @@ spinner() {
   local chars='/-\\|'
   for i in {1..20}; do
     for j in {0..3}; do
-      printf "\rĐang khởi động ứng dụng... %s" "${chars:j:1}"
+      printf "\r${GREEN}Đang khởi động ứng dụng... %s${RESET}" "${chars:j:1}"
       sleep 0.2
     done
   done
@@ -41,4 +47,4 @@ spinner
 # 4) Launch Streamlit UI
 streamlit run main_engine/app.py
 
-echo "Ứng dụng đã thoát. Nhấn Ctrl+C để đóng terminal." 
+echo -e "${YELLOW}Ứng dụng đã thoát. Nhấn Ctrl+C để đóng terminal.${RESET}"

--- a/setup.cmd
+++ b/setup.cmd
@@ -2,11 +2,12 @@
 setlocal enableextensions enabledelayedexpansion
 
 :: Thiết lập màu sắc và tiêu đề cho giao diện thân thiện hơn
-color 0A
+color 0E
 cls
-echo ======================================================
-echo                 RESUME AI - CÀI ĐẶT
-echo ======================================================
+powershell -NoProfile -Command "Write-Host '=====================================================' -ForegroundColor Cyan"
+powershell -NoProfile -Command "$t='RESUME AI - CÀI ĐẶT'; $c=@('Red','Yellow','Green','Cyan','Magenta','Blue','White'); for($i=0;$i -lt $t.Length;$i++){Write-Host -NoNewline $t[$i] -ForegroundColor $c[$i % $c.Count]} ; Write-Host ''"
+powershell -NoProfile -Command "Write-Host '=====================================================' -ForegroundColor Cyan"
+color 07
 :: ======================================================
 :: Resume AI - Setup Script
 :: Mục đích: Tự động thiết lập môi trường dự án
@@ -56,7 +57,7 @@ if not exist "%~dp0.env" (
 
 :: 3) Tạo virtual environment nếu chưa có
 if not exist "%~dp0.venv\Scripts\activate.bat" (
-echo 📦 Đang tạo môi trường ảo...
+powershell -NoProfile -Command "Write-Host '📦 Đang tạo môi trường ảo...' -ForegroundColor Green"
     python -m venv "%~dp0.venv"
 echo Đã tạo môi trường ảo.
 ) else (
@@ -68,7 +69,7 @@ call "%~dp0.venv\Scripts\activate.bat"
 echo Đã kích hoạt môi trường ảo.
 
 :: 5) Cài đặt dependencies
-echo Đang cài đặt dependencies...
+powershell -NoProfile -Command "Write-Host 'Đang cài đặt dependencies...' -ForegroundColor Green"
 pip install --upgrade uv
 uv pip install --upgrade pip
 uv pip install -r "%~dp0requirements.txt"
@@ -82,5 +83,5 @@ if not exist "%~dp0attachments" (
     echo Thư mục attachments đã tồn tại.
 )
 
-echo Quá trình cài đặt hoàn tất! Nhấn phím bất kỳ để thoát.
+powershell -NoProfile -Command "Write-Host 'Quá trình cài đặt hoàn tất! Nhấn phím bất kỳ để thoát.' -ForegroundColor Yellow"
 pause

--- a/setup.sh
+++ b/setup.sh
@@ -2,12 +2,18 @@
 
 set -e
 
-GREEN="\033[0;32m"
+YELLOW="\033[1;33m"
+WHITE="\033[1;37m"
+GREEN="\033[0;92m"
 RESET="\033[0m"
 
-echo -e "${GREEN}======================================================"
-echo -e "             RESUME AI - SETUP SCRIPT             "
-echo -e "======================================================${RESET}"
+echo -e "${GREEN}======================================================${RESET}"
+if command -v lolcat >/dev/null 2>&1; then
+  echo "             RESUME AI - SETUP SCRIPT             " | lolcat
+else
+  echo -e "${YELLOW}             RESUME AI - SETUP SCRIPT             ${RESET}"
+fi
+echo -e "${GREEN}======================================================${RESET}"
 
 # 1) Check Python
 if ! command -v python3 >/dev/null 2>&1; then
@@ -47,4 +53,4 @@ pip install -r requirements.txt
 # 6) Create folders
 mkdir -p attachments output log
 
-echo -e "${GREEN}Setup hoàn tất!${RESET}"
+echo -e "${YELLOW}Setup hoàn tất!${RESET}"


### PR DESCRIPTION
## Summary
- give run scripts a colorful banner and spinner text
- update setup scripts with colorful lolcat-style header

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854f2f631d08324a30a6c978e5ee91d