### PR TITLE
Fix encoding and color reset in setup scripts

### DIFF
--- a/run_resume_ai.cmd
+++ b/run_resume_ai.cmd
@@ -2,6 +2,8 @@
 :: 0) Chuyển console sang UTF-8 (hỗ trợ tiếng Việt)
 chcp 65001 >nul
 setlocal enableextensions enabledelayedexpansion
+:: Đảm bảo PowerShell cũng dùng UTF-8 để hiển thị tiếng Việt
+powershell -NoProfile -Command "[Console]::OutputEncoding=[System.Text.Encoding]::UTF8"
 
 :: Hiển thị banner nhiều màu
 color 0E
@@ -33,17 +35,18 @@ if exist "%~dp0.venv\Scripts\activate.bat" (
 
 :: 3) Loading animation trước khi chạy UI
 color 0A
-set "spin=/ - \ |"
-for /L %%n in (1,1,20) do (
+set "spin=- \ | /"
+for /L %%n in (1,1,8) do (
     set /A idx=%%n %% 4
     for %%c in (!spin:~!idx!,1!) do <nul set /p "=Đang khởi động ứng dụng... %%c\r"
-    ping 127.0.0.1 -n 2 > nul
+    ping 127.0.0.1 -n 1 > nul
 )
 echo.
 color 07
 
 :: 4) Khởi động Streamlit UI
 streamlit run "%~dp0main_engine\app.py"
+color 07
 
 powershell -NoProfile -Command "Write-Host 'Ứng dụng đã thoát. Nhấn phím bất kỳ để đóng.' -ForegroundColor Yellow"
 pause

--- a/run_resume_ai.sh
+++ b/run_resume_ai.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
+export LC_ALL=C.UTF-8
 
 YELLOW="\033[1;33m"
 WHITE="\033[1;37m"
@@ -32,13 +33,14 @@ fi
 
 # 3) Loading animation
 spinner() {
-  local chars='/-\\|'
-  for i in {1..20}; do
+  local chars='-\|/'
+  for i in {1..8}; do
     for j in {0..3}; do
       printf "\r${GREEN}Đang khởi động ứng dụng... %s${RESET}" "${chars:j:1}"
-      sleep 0.2
+      sleep 0.1
     done
   done
+  tput sgr0
   echo
 }
 

--- a/setup.cmd
+++ b/setup.cmd
@@ -2,6 +2,8 @@
 :: 0) Chuyển console sang UTF-8
 chcp 65001 >nul
 setlocal enableextensions enabledelayedexpansion
+:: Đảm bảo PowerShell cũng dùng UTF-8 để hiển thị tiếng Việt
+powershell -NoProfile -Command "[Console]::OutputEncoding=[System.Text.Encoding]::UTF8"
 
 :: Thiết lập màu sắc và tiêu đề cho giao diện thân thiện hơn
 color 0E
@@ -84,3 +86,4 @@ if not exist "%~dp0attachments" (
 
 powershell -NoProfile -Command "Write-Host 'Quá trình cài đặt hoàn tất! Nhấn phím bất kỳ để thoát.' -ForegroundColor Yellow"
 pause
+color 07

--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
+export LC_ALL=C.UTF-8
 
 YELLOW="\033[1;33m"
 WHITE="\033[1;37m"


### PR DESCRIPTION
## Summary
- set PowerShell output to UTF-8 in the Windows setup script
- reset console color at exit
- export UTF-8 locale in the shell setup script
- run tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6854f606f4c48324a78a2a5d6628089b