### PR TITLE
Fix script paths and encoding

### DIFF
--- a/run_resume_ai.cmd
+++ b/run_resume_ai.cmd
@@ -1,8 +1,8 @@
 @echo off
-:: 0) Chuyển console sang UTF-8 (hỗ trợ tiếng Việt)
+:: 0) Switch console to UTF-8
 chcp 65001 >nul
 setlocal enableextensions enabledelayedexpansion
-:: Đảm bảo PowerShell cũng dùng UTF-8 để hiển thị tiếng Việt
+:: Ensure PowerShell also uses UTF-8 for Vietnamese text
 powershell -NoProfile -Command "[Console]::OutputEncoding=[System.Text.Encoding]::UTF8"
 
 :: Hiển thị banner nhiều màu
@@ -19,18 +19,18 @@ color 07
 :: 1) Kiểm tra Python
 python --version >nul 2>&1
 if errorlevel 1 (
-    echo [ERROR] Python không được cài đặt hoặc không tìm thấy trong PATH.
+    powershell -NoProfile -Command "Write-Host '[ERROR] Python không được cài đặt hoặc không tìm thấy trong PATH.' -ForegroundColor Red"
     pause
     exit /b 1
 )
-echo [OK] Đã có Python.
+powershell -NoProfile -Command "Write-Host '[OK] Đã có Python.' -ForegroundColor Green"
 
 :: 2) Kích hoạt virtual environment nếu có
 if exist "%~dp0.venv\Scripts\activate.bat" (
     call "%~dp0.venv\Scripts\activate.bat"
-    echo [OK] Môi trường ảo đã được kích hoạt.
+    powershell -NoProfile -Command "Write-Host '[OK] Môi trường ảo đã được kích hoạt.' -ForegroundColor Green"
 ) else (
-    echo [CẢNH BÁO] Không tìm thấy môi trường ảo tại .venv, sẽ dùng Python toàn cục.
+    powershell -NoProfile -Command "Write-Host '[CẢNH BÁO] Không tìm thấy môi trường ảo tại .venv, sẽ dùng Python toàn cục.' -ForegroundColor Yellow"
 )
 
 :: 3) Loading animation trước khi chạy UI

--- a/run_resume_ai.sh
+++ b/run_resume_ai.sh
@@ -2,8 +2,11 @@
 set -e
 export LC_ALL=C.UTF-8
 
+# Determine script directory so relative paths work from anywhere
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
 YELLOW="\033[1;33m"
-WHITE="\033[1;37m"
 GREEN="\033[0;92m"
 RESET="\033[0m"
 

--- a/setup.cmd
+++ b/setup.cmd
@@ -1,8 +1,8 @@
 @echo off
-:: 0) Chuyển console sang UTF-8
+:: 0) Switch console to UTF-8
 chcp 65001 >nul
 setlocal enableextensions enabledelayedexpansion
-:: Đảm bảo PowerShell cũng dùng UTF-8 để hiển thị tiếng Việt
+:: Ensure PowerShell also uses UTF-8 for Vietnamese text
 powershell -NoProfile -Command "[Console]::OutputEncoding=[System.Text.Encoding]::UTF8"
 
 :: Thiết lập màu sắc và tiêu đề cho giao diện thân thiện hơn
@@ -25,63 +25,63 @@ color 07
 :: 1) Kiểm tra Python
 python --version >nul 2>&1
 if errorlevel 1 (
-    echo Python không được cài đặt hoặc không tìm thấy trong PATH. Đang thử cài đặt Python...
+    powershell -NoProfile -Command "Write-Host 'Python không được cài đặt hoặc không tìm thấy trong PATH. Đang thử cài đặt Python...' -ForegroundColor Red"
     where winget >nul 2>&1
     if errorlevel 1 (
-        echo Không tìm thấy winget để cài đặt Python tự động.
-        echo Vui lòng cài đặt Python thủ công tại https://www.python.org.
+        powershell -NoProfile -Command "Write-Host 'Không tìm thấy winget để cài đặt Python tự động.' -ForegroundColor Yellow"
+        powershell -NoProfile -Command "Write-Host 'Vui lòng cài đặt Python thủ công tại https://www.python.org.'"
         pause
         exit /b 1
     )
     winget install --id Python.Python.3.11 --silent --accept-package-agreements --accept-source-agreements
     if errorlevel 1 (
-        echo Lỗi cài đặt Python bằng winget.
-        echo Vui lòng cài đặt Python thủ công tại https://www.python.org rồi chạy lại script.
+        powershell -NoProfile -Command "Write-Host 'Lỗi cài đặt Python bằng winget.' -ForegroundColor Red"
+        powershell -NoProfile -Command "Write-Host 'Vui lòng cài đặt Python thủ công tại https://www.python.org rồi chạy lại script.'"
         pause
         exit /b 1
     )
-    echo Hoàn tất cài đặt Python.
+    powershell -NoProfile -Command "Write-Host 'Hoàn tất cài đặt Python.' -ForegroundColor Green"
 )
-echo Đã có Python.
+powershell -NoProfile -Command "Write-Host 'Đã có Python.' -ForegroundColor Green"
 
 :: 2) Copy .env.example thành .env nếu chưa tồn tại
 if not exist "%~dp0.env" (
     if exist "%~dp0.env.example" (
         copy "%~dp0.env.example" "%~dp0.env" >nul
-        echo Đã tạo file .env từ .env.example. Vui lòng chỉnh sửa giá trị.
+        powershell -NoProfile -Command "Write-Host 'Đã tạo file .env từ .env.example. Vui lòng chỉnh sửa giá trị.'"
     ) else (
-        echo Không tìm thấy .env.example. Hãy tạo file .env thủ công.
+        powershell -NoProfile -Command "Write-Host 'Không tìm thấy .env.example. Hãy tạo file .env thủ công.' -ForegroundColor Yellow"
     )
 ) else (
-    echo File .env đã tồn tại.
+    powershell -NoProfile -Command "Write-Host 'File .env đã tồn tại.'"
 )
 
 :: 3) Tạo virtual environment nếu chưa có
 if not exist "%~dp0.venv\Scripts\activate.bat" (
 powershell -NoProfile -Command "Write-Host '📦 Đang tạo môi trường ảo...' -ForegroundColor Green"
     python -m venv "%~dp0.venv"
-echo Đã tạo môi trường ảo.
+powershell -NoProfile -Command "Write-Host 'Đã tạo môi trường ảo.' -ForegroundColor Green"
 ) else (
-    echo Môi trường ảo đã tồn tại.
+    powershell -NoProfile -Command "Write-Host 'Môi trường ảo đã tồn tại.'"
 )
 
 :: 4) Kích hoạt virtual environment
 call "%~dp0.venv\Scripts\activate.bat"
-echo Đã kích hoạt môi trường ảo.
+powershell -NoProfile -Command "Write-Host 'Đã kích hoạt môi trường ảo.' -ForegroundColor Green"
 
 :: 5) Cài đặt dependencies
 powershell -NoProfile -Command "Write-Host 'Đang cài đặt dependencies...' -ForegroundColor Green"
 pip install --upgrade uv
 uv pip install --upgrade pip
 uv pip install -r "%~dp0requirements.txt"
-echo Hoàn tất cài đặt dependencies.
+powershell -NoProfile -Command "Write-Host 'Hoàn tất cài đặt dependencies.' -ForegroundColor Green"
 
 :: 6) Tạo thư mục attachments
 if not exist "%~dp0attachments" (
     mkdir "%~dp0attachments"
-    echo Đã tạo thư mục attachments.
+    powershell -NoProfile -Command "Write-Host 'Đã tạo thư mục attachments.'"
 ) else (
-    echo Thư mục attachments đã tồn tại.
+    powershell -NoProfile -Command "Write-Host 'Thư mục attachments đã tồn tại.'"
 )
 
 powershell -NoProfile -Command "Write-Host 'Quá trình cài đặt hoàn tất! Nhấn phím bất kỳ để thoát.' -ForegroundColor Yellow"

--- a/setup.sh
+++ b/setup.sh
@@ -3,8 +3,11 @@
 set -e
 export LC_ALL=C.UTF-8
 
+# Determine script directory so relative paths work from anywhere
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
 YELLOW="\033[1;33m"
-WHITE="\033[1;37m"
 GREEN="\033[0;92m"
 RESET="\033[0m"
 


### PR DESCRIPTION
## Summary
- adjust Windows command scripts to use PowerShell for UTF-8 output
- add script-dir detection to `run_resume_ai.sh` and `setup.sh`
- drop unused `WHITE` variable in shell scripts

## Testing
- `bash run_resume_ai.sh` from another directory
- `bash setup.sh` from another directory
- `pytest -q` *(fails: ModuleNotFoundError: streamlit)*

------
https://chatgpt.com/codex/tasks/task_e_68550357c6988324a17c6140378b8233