### PR TITLE
Fix theme via Streamlit config

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,7 @@
+[theme]
+base="dark"
+primaryColor="#FFFB00"
+backgroundColor="#0D0F12"
+secondaryBackgroundColor="#0D0F12"
+textColor="#E6E6E6"
+font="sans serif"

--- a/main_engine/app.py
+++ b/main_engine/app.py
@@ -138,6 +138,13 @@ def load_css():
 
 load_css()
 
+# --- Apply theme from Streamlit config ---
+theme = st.get_option("theme.base") or "light"
+st.markdown(
+    f"<script>document.documentElement.setAttribute('data-theme', '{theme}');</script>",
+    unsafe_allow_html=True,
+)
+
 # --- Sidebar: logo và cấu hình LLM ---
 logo_path = ROOT / "static" / "logo.png"
 if logo_path.exists():


### PR DESCRIPTION
## Summary
- read theme from `st.get_option("theme.base")`
- inject theme into page based on config
- add `.streamlit/config.toml` with custom dark palette

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68552a424a488324ab7a727ab5367805