### PR TITLE
Fix theme variables

### DIFF
--- a/main_engine/app.py
+++ b/main_engine/app.py
@@ -138,6 +138,38 @@ def load_css():
 
 load_css()
 
+# --- Apply theme from Streamlit config ---
+def apply_theme():
+    base = (st.get_option("theme.base") or "light").lower()
+    if base == "dark":
+        css = """
+        :root {
+            --cv-text-color: #E6E6E6;
+            --cv-bg-color: #0D0F12;
+            --cv-accent-color: #0D0F12;
+            --btn-gold: #00FFF7;
+            --btn-gold-border: #FF31FF;
+            --logo-gold: #FFFB00;
+            --logo-shadow: rgba(255, 251, 0, 0.4);
+        }
+        """
+    else:
+        css = """
+        :root {
+            --cv-text-color: #2D3748;
+            --cv-bg-color: #FFFFFF;
+            --cv-accent-color: #F4F6F8;
+            --btn-gold: #2B6CB0;
+            --btn-gold-border: #2B6CB0;
+            --logo-gold: #FCD129;
+            --logo-shadow: rgba(252, 209, 41, 0.4);
+        }
+        """
+    st.markdown(f"<style>{css}</style>", unsafe_allow_html=True)
+
+
+apply_theme()
+
 # --- Sidebar: logo và cấu hình LLM ---
 logo_path = ROOT / "static" / "logo.png"
 if logo_path.exists():

--- a/static/style.css
+++ b/static/style.css
@@ -1,8 +1,8 @@
 /* static/style.css */
 
 /* Theme variables */
-html[data-theme='light'] {
-  /* Office Light Theme Palette */
+:root {
+  /* Default palette is Office Light; overridden dynamically for dark mode */
   --cv-text-color: #2D3748; /* Text Primary */
   --cv-bg-color: #FFFFFF; /* Background */
   --cv-accent-color: #F4F6F8; /* Surface */
@@ -12,26 +12,10 @@ html[data-theme='light'] {
   --logo-shadow: rgba(252, 209, 41, 0.4);
 }
 
-/* Logo contrast enhancement: specific to logo filename */
-html[data-theme='light'] img[src*="logo.png"] {
-  /* dark drop shadow around bright logo */
-  filter: drop-shadow(0 0 12px rgba(0,0,0,0.8));
+/* Logo contrast enhancement */
+img[src*="logo.png"] {
+  filter: drop-shadow(0 0 12px rgba(0, 0, 0, 0.8));
   max-width: 180px;
-}
-html[data-theme='dark'] img[src*="logo.png"] {
-  /* light drop shadow around logo */
-  filter: drop-shadow(0 0 12px rgba(255,255,255,0.9));
-  max-width: 180px;
-}
-html[data-theme='dark'] {
-  /* Dark Neon Cyberpunk Coder Palette */
-  --cv-text-color: #E6E6E6; /* Text Primary */
-  --cv-bg-color: #0D0F12; /* Background */
-  --cv-accent-color: #0D0F12; /* No separate surface color provided */
-  --btn-gold: #00FFF7; /* Primary Neon */
-  --btn-gold-border: #FF31FF; /* Secondary Neon */
-  --logo-gold: #FFFB00; /* Tertiary Neon */
-  --logo-shadow: rgba(255, 251, 0, 0.4);
 }
 
 /* Global background and text */


### PR DESCRIPTION
## Summary
- remove custom theme config
- load palette via `apply_theme` and override Streamlit light/dark
- simplify CSS to use `:root` variables

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68552a424a488324ab7a727ab5367805

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The app now dynamically adjusts its appearance based on the selected theme, updating colors and styles automatically.

- **Style**
  - Unified the light theme as the default style throughout the app.
  - Simplified logo image styling for a consistent look.
  - Removed dark theme-specific styles for a cleaner and more streamlined appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->