### PR TITLE
Fix gemini model name

### DIFF
--- a/modules/config.py
+++ b/modules/config.py
@@ -28,7 +28,7 @@ def _get_env(varname: str, default: str = "") -> str:
 
 # --- Nhà cung cấp (provider) và model mặc định ---
 LLM_PROVIDER = _get_env("LLM_PROVIDER", "google").lower()
-LLM_MODEL = _get_env("LLM_MODEL", "gemini-2.0-flask")
+LLM_MODEL = _get_env("LLM_MODEL", "gemini-2.0-flash")
 
 # --- Khóa API cho Google, OpenRouter và các platform khác (không bắt buộc) ---
 GOOGLE_API_KEY = _get_env("GOOGLE_API_KEY")
@@ -94,7 +94,7 @@ GOOGLE_FALLBACK_MODELS: List[str] = [
     "gemini-1.5-pro", "gemini-1.5-pro-latest", "gemini-pro", "gemini-pro-vision",
     # Newer and experimental variants
     "gemini-2.0-alpha", "gemini-2.0-vision", "gemini-2.0-vision-extended",
-    "gemini-2.0-flask",
+    "gemini-2.0-flash",
     "gemini-2.5-pro", "gemini-2.5-pro-latest"
 ]
 OPENROUTER_FALLBACK_MODELS: List[str] = [
@@ -111,7 +111,7 @@ MODEL_PRICES: Dict[str, str] = {
     "gemini-1.5-pro-latest": "1$/token",
     "gemini-pro": "1$/token",
     "gemini-pro-vision": "1$/token",
-    "gemini-2.0-flask": "unknown",
+    "gemini-2.0-flash": "unknown",
     # OpenRouter fallback models (giá tham khảo, có thể thay đổi)
     "anthropic/claude-3.5-sonnet": "variable",
     "anthropic/claude-3-haiku": "variable",

--- a/simple_app.py
+++ b/simple_app.py
@@ -37,7 +37,7 @@ provider = st.selectbox(
     "Provider", ["google", "openrouter"], help="Chọn nhà cung cấp LLM"
 )
 api_key = st.text_input("API Key", type="password", help="Nhập khóa API cho provider")
-model = st.text_input("Model", "gemini-2.0-flask", help="Tên model muốn sử dụng")
+model = st.text_input("Model", "gemini-2.0-flash", help="Tên model muốn sử dụng")
 
 # --- Step 2: Fetch CV from email ---
 st.header("Bước 1: Lấy CV từ Email")


### PR DESCRIPTION
## Summary
- fix default model name from gemini-2.0-flask to gemini-2.0-flash in `modules/config.py` and `simple_app.py`
- update fallback models and prices accordingly
- run tests

## Testing
- `python -m pytest -q test/`

------
https://chatgpt.com/codex/tasks/task_e_68553baa0af483249b4ec48bcfe35335