### PR TITLE
Add health check script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ log/*
 .venv
 FIX_REPORT.md
 health_check_report.json
-health_check.py
 UPGRADE_REPORT.md
 CHAT_TAB_FIX_REPORT.md
 test_chat_tab.py

--- a/health_check.py
+++ b/health_check.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import importlib
+
+errors = []
+
+# Check Python version
+if sys.version_info < (3, 7):
+    errors.append("Python 3.7+ is required")
+
+# Check required module
+try:
+    importlib.import_module('streamlit')
+except ImportError:
+    errors.append("Missing required package: streamlit")
+
+# Check essential directories
+for d in ["attachments", "csv", "log", "static"]:
+    if not os.path.isdir(d):
+        errors.append(f"Missing directory: {d}")
+
+# Check for environment file
+if not os.path.isfile('.env'):
+    errors.append(".env file not found")
+
+if errors:
+    print("Health check failed:")
+    for e in errors:
+        print(f" - {e}")
+    sys.exit(1)
+
+print("All checks passed")


### PR DESCRIPTION
## Summary
- create a simple `health_check.py` for basic environment checks
- stop ignoring `health_check.py` in `.gitignore`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: cannot import QAChatbot)*
- `python health_check.py`

------
https://chatgpt.com/codex/tasks/task_e_68553baad9888324a813625dcde9bd71