### PR TITLE
Simplify web UI

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,7 +1,7 @@
 [theme]
-base="dark"
-primaryColor="#FFFB00"
-backgroundColor="#0D0F12"
-secondaryBackgroundColor="#0D0F12"
-textColor="#E6E6E6"
-font="sans serif"
+base = "light"
+primaryColor = "#2B6CB0"
+backgroundColor = "#FFFFFF"
+secondaryBackgroundColor = "#F4F6F8"
+textColor = "#2D3748"
+font = "sans serif"

--- a/simple_app.py
+++ b/simple_app.py
@@ -10,6 +10,8 @@ from modules.config import (
     OUTPUT_CSV,
     EMAIL_HOST,
     EMAIL_PORT,
+    LLM_PROVIDER,
+    LLM_MODEL,
 )
 
 ROOT = Path(__file__).parent
@@ -27,20 +29,18 @@ st.set_page_config(page_title="Resume AI Simple Mode", page_icon=page_icon)
 load_css()
 
 if logo_path.exists():
-    st.image(str(logo_path), width=180)
+    st.image(str(logo_path))
 
-st.title("Resume AI - Simple Mode")
-st.markdown("Làm theo từng bước để tải và xử lý CV một cách dễ dàng.")
+st.title("Resume AI")
+st.markdown("Nhập thông tin cần thiết và xử lý CV đơn giản.")
 
-# --- Step 1: API config ---
-provider = st.selectbox(
-    "Provider", ["google", "openrouter"], help="Chọn nhà cung cấp LLM"
-)
-api_key = st.text_input("API Key", type="password", help="Nhập khóa API cho provider")
-model = st.text_input("Model", "gemini-2.0-flash", help="Tên model muốn sử dụng")
+# --- API config ---
+provider = LLM_PROVIDER
+model = LLM_MODEL
+api_key = st.text_input("API Key", type="password", help="Khóa API cho mô hình")
 
-# --- Step 2: Fetch CV from email ---
-st.header("Bước 1: Lấy CV từ Email")
+# --- Fetch CV from email ---
+st.header("Lấy CV từ Email")
 email_user = st.text_input("Gmail", help="Địa chỉ Gmail để lấy CV")
 email_pass = st.text_input(
     "Mật khẩu", type="password", help="Mật khẩu hoặc App Password"
@@ -59,8 +59,8 @@ if st.button("Fetch CV"):
         else:
             st.info("Không có file mới.")
 
-# --- Step 3: Process CV ---
-st.header("Bước 2: Xử lý CV")
+# --- Process CV ---
+st.header("Xử lý CV")
 if st.button("Process CV"):
     cv_files = [
         str(p)
@@ -97,8 +97,8 @@ if st.button("Process CV"):
         processor.save_to_csv(df, str(OUTPUT_CSV))
         st.success(f"Đã xử lý {len(df)} CV. Kết quả lưu ở {OUTPUT_CSV}")
 
-# --- Step 4: View results ---
-st.header("Bước 3: Xem kết quả")
+# --- View results ---
+st.header("Xem kết quả")
 if OUTPUT_CSV.exists():
     df = pd.read_csv(OUTPUT_CSV, encoding="utf-8-sig")
     st.dataframe(df, use_container_width=True)

--- a/static/style.css
+++ b/static/style.css
@@ -1,37 +1,16 @@
 /* static/style.css */
 
-/* Theme variables */
-html[data-theme='light'] {
-  /* Office Light Theme Palette */
-  --cv-text-color: #2D3748; /* Text Primary */
-  --cv-bg-color: #FFFFFF; /* Background */
-  --cv-accent-color: #F4F6F8; /* Surface */
-  --btn-gold: #2B6CB0; /* Primary Accent */
+/* Simple theme variables */
+:root {
+  --cv-text-color: #2D3748;
+  --cv-bg-color: #FFFFFF;
+  --cv-accent-color: #F4F6F8;
+  --btn-gold: #2B6CB0;
   --btn-gold-border: #2B6CB0;
-  --logo-gold: #FCD129;
-  --logo-shadow: rgba(252, 209, 41, 0.4);
 }
 
-/* Logo contrast enhancement: specific to logo filename */
-html[data-theme='light'] img[src*="logo.png"] {
-  /* dark drop shadow around bright logo */
-  filter: drop-shadow(0 0 12px rgba(0,0,0,0.8));
-  max-width: 180px;
-}
-html[data-theme='dark'] img[src*="logo.png"] {
-  /* light drop shadow around logo */
-  filter: drop-shadow(0 0 12px rgba(255,255,255,0.9));
-  max-width: 180px;
-}
-html[data-theme='dark'] {
-  /* Dark Neon Cyberpunk Coder Palette */
-  --cv-text-color: #E6E6E6; /* Text Primary */
-  --cv-bg-color: #0D0F12; /* Background */
-  --cv-accent-color: #0D0F12; /* No separate surface color provided */
-  --btn-gold: #00FFF7; /* Primary Neon */
-  --btn-gold-border: #FF31FF; /* Secondary Neon */
-  --logo-gold: #FFFB00; /* Tertiary Neon */
-  --logo-shadow: rgba(255, 251, 0, 0.4);
+img[src*="logo.png"] {
+  max-width: 160px;
 }
 
 /* Global background and text */
@@ -39,23 +18,6 @@ body {
   background-color: var(--cv-bg-color) !important;
   color: var(--cv-text-color) !important;
   font-size: 1.05rem;
-}
-
-.stApp {
-  border: 2px solid var(--logo-gold);
-  box-shadow: 0 0 12px var(--logo-shadow);
-  border-radius: 8px;
-  padding: 8px;
-}
-
-/* Enhance logo contrast: apply drop-shadow to any image in sidebar */
-aside[data-testid="stSidebar"] img,
-div[data-testid="stSidebar"] img {
-  filter: drop-shadow(0 0 8px rgba(0,0,0,0.8)) !important;
-}
-
-h1, h2, h3 {
-  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
 }
 
 /* Button styling for BaseWeb buttons */


### PR DESCRIPTION
## Summary
- switch to a light Streamlit theme
- slim down custom CSS and remove neon effects
- simplify `simple_app.py` to use default provider and model

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_685582e9fde08324be89bfa516070933