### PR TITLE
Fix dark mode neon text color

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,7 +1,7 @@
 [theme]
-base = "light"
+base = "dark"
 primaryColor = "#2B6CB0"
-backgroundColor = "#FFFFFF"
-secondaryBackgroundColor = "#F4F6F8"
-textColor = "#2D3748"
+backgroundColor = "#000000"
+secondaryBackgroundColor = "#333333"
+textColor = "#FFFF33"
 font = "sans serif"


### PR DESCRIPTION
## Summary
- switch Streamlit to dark theme
- set neon yellow text color
- adjust background colors for dark mode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68558c03a89c8324bdd084c900e9cfa9