### PR TITLE
Enforce log directory usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,7 +77,7 @@ TEMP_DIR=./temp               # Thư mục tạm
 OUTPUT_CSV=csv/cv_analysis.csv    # File CSV tổng hợp
 OUTPUT_JSON=json/cv_analysis.json   # File JSON chi tiết
 OUTPUT_EXCEL=excel/cv_analysis.xlsx  # File Excel báo cáo
-CHAT_LOG_FILE=.log/chat_log.json  # Log cuộc trò chuyện
+CHAT_LOG_FILE=log/chat_log.json  # Log cuộc trò chuyện
 
 # =======================================================================
 # 🚨 SECURITY & LOGGING
@@ -90,7 +90,7 @@ ENABLE_REQUEST_LOGGING=false   # Log các API requests (tắt để bảo mật)
 
 # Cấu hình logging
 LOG_LEVEL=INFO                 # DEBUG, INFO, WARNING, ERROR
-LOG_FILE=./logs/app.log       # File log
+LOG_FILE=log/app.log          # File log
 LOG_MAX_SIZE=10MB             # Kích thước tối đa file log
 LOG_BACKUP_COUNT=5            # Số file backup
 
@@ -155,7 +155,7 @@ ENABLE_FILE_SCAN=true         # Quét virus/malware
 #    - Sử dụng App Password làm EMAIL_PASS
 # 
 # 4. Tạo thư mục cần thiết:
-#    mkdir attachments output temp logs
+#    mkdir attachments output temp log
 # 
 # 5. Kiểm tra cấu hình:
 #    python config_check.py

--- a/main_engine/app.py
+++ b/main_engine/app.py
@@ -13,6 +13,10 @@ ROOT = HERE.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
+# Ensure log directory exists
+LOG_DIR = ROOT / "log"
+LOG_DIR.mkdir(parents=True, exist_ok=True)
+
 # Khi chạy bằng `streamlit run`, __package__ sẽ là None dẫn tới lỗi khi
 # dùng relative imports. Thiết lập thủ công để các import như
 # `from .tabs import fetch_tab` hoạt động.
@@ -31,7 +35,7 @@ logging.basicConfig(
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
     handlers=[
         logging.StreamHandler(sys.stdout),
-        logging.FileHandler(ROOT / "app.log", encoding='utf-8')
+        logging.FileHandler(LOG_DIR / "app.log", encoding='utf-8')
     ]
 )
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- centralize application log output to `log/` directory
- update `.env.example` to match new log paths

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685590dd93b48324a41bfa8d271a1dc5