### PR TITLE
Improve dark theme colors

### DIFF
--- a/main_engine/app.py
+++ b/main_engine/app.py
@@ -725,9 +725,9 @@ st.markdown(
 
 # Adjust style variables based on chosen Streamlit theme
 if theme == "dark":
-    st.session_state["text_color"] = "#ffff33"
-    st.session_state["background_color"] = "#332a16"
-    st.session_state["secondary_color"] = "#9b7e3c"
+    st.session_state["text_color"] = "#f0f0f0"
+    st.session_state["background_color"] = "#1e1e1e"
+    st.session_state["secondary_color"] = "#2c2c2c"
 else:
     st.session_state["text_color"] = "#000000"
     st.session_state["background_color"] = "#fffbf0"

--- a/static/style.css
+++ b/static/style.css
@@ -10,9 +10,9 @@
 }
 
 :root[data-theme="dark"] {
-  --cv-text-color: #ffff33;
-  --cv-bg-color: #332a16;
-  --cv-accent-color: #9b7e3c;
+  --cv-text-color: #f0f0f0;
+  --cv-bg-color: #1e1e1e;
+  --cv-accent-color: #2c2c2c;
   --btn-gold: #d4af37;
   --btn-gold-border: #d4af37;
 }


### PR DESCRIPTION
## Summary
- tweak CSS variables for dark mode colors
- update app theme variable assignment for dark mode

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'streamlit')*

------
https://chatgpt.com/codex/tasks/task_e_68559401a80c83248e79c0621c01982d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated dark theme colors for improved readability and a modern appearance, including lighter text and darker background and accent colors. Light theme remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->