### PR TITLE
Adjust button text colors based on theme

### DIFF
--- a/main_engine/app.py
+++ b/main_engine/app.py
@@ -986,7 +986,7 @@ custom_css = f"""
     
     .stButton > button {{
         background: linear-gradient(135deg, {accent_color} 0%, {secondary_color} 100%);
-        color: white;
+        color: var(--btn-text-color);
         border-radius: {border_radius}px;
         border: none;
         padding: 0.6rem 1.2rem;

--- a/static/style.css
+++ b/static/style.css
@@ -8,6 +8,7 @@
   --cv-accent-color: #f4e09c;
   --btn-gold: #d4af37;
   --btn-gold-border: #d4af37;
+  --btn-text-color: #000000;
 }
 
 :root[data-theme="dark"] {
@@ -16,6 +17,7 @@
   --cv-accent-color: #2c2c2c;
   --btn-gold: #d4af37;
   --btn-gold-border: #d4af37;
+  --btn-text-color: #ffff33;
 }
 
 img[src*="logo.png"] {
@@ -33,7 +35,7 @@ body {
 /* Button styling for BaseWeb buttons */
 button[data-baseweb="base-button"] {
   background-color: var(--btn-gold) !important;
-  color: var(--cv-bg-color) !important;
+  color: var(--btn-text-color) !important;
   border: 2px solid var(--btn-gold-border) !important;
   border-radius: 4px !important;
   font-size: 1rem !important;


### PR DESCRIPTION
## Summary
- add `--btn-text-color` variable for light and dark themes
- use the variable for BaseWeb button text
- update injected CSS to reference the new variable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685596533cb4832491f0f5f8ef6669a0