### PR TITLE
Improve chat action buttons layout

### DIFF
--- a/main_engine/app.py
+++ b/main_engine/app.py
@@ -353,8 +353,8 @@ def render_enhanced_chat_tab():
     # Chat input form
     render_chat_input_form()
     
-    # Action buttons
-    col1, col2, col3, col4 = st.columns(4)
+    # Action buttons arranged closely
+    col1, col2, col3, col4, _ = st.columns([0.3, 0.3, 0.3, 0.3, 3])
     
     with col1:
         if st.button("🗑️ Xóa lịch sử", help="Xóa toàn bộ lịch sử chat"):

--- a/static/style.css
+++ b/static/style.css
@@ -17,7 +17,7 @@
   --cv-accent-color: #2c2c2c;
   --btn-gold: #d4af37;
   --btn-gold-border: #d4af37;
-  --btn-text-color: #ffff33;
+  --btn-text-color: #ffff00;
 }
 
 img[src*="logo.png"] {


### PR DESCRIPTION
## Summary
- keep chat action buttons closer using an extra spacer column
- show neon yellow button text on dark theme

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68567022cedc8324b525408d45625363