### PR TITLE
Fix button text wrapping

### DIFF
--- a/main_engine/app.py
+++ b/main_engine/app.py
@@ -354,7 +354,7 @@ def render_enhanced_chat_tab():
     render_chat_input_form()
     
     # Action buttons arranged closely
-    col1, col2, col3, col4, _ = st.columns([0.3, 0.3, 0.3, 0.3, 3])
+    col1, col2, col3, col4, _ = st.columns([1, 1, 1, 1, 3])
     
     with col1:
         if st.button("🗑️ Xóa lịch sử", help="Xóa toàn bộ lịch sử chat"):

--- a/static/style.css
+++ b/static/style.css
@@ -40,6 +40,7 @@ button[data-baseweb="base-button"] {
   border-radius: 4px !important;
   font-size: 1rem !important;
   padding: 12px 24px !important;
+  white-space: nowrap;
   transition: background-color 0.2s, color 0.2s !important;
 }
 button[data-baseweb="base-button"]:hover {


### PR DESCRIPTION
## Summary
- keep button text on one line with `white-space: nowrap`
- widen control column layout in chat tab

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68567246f3988324a24a0fb787009ae6