### PR TITLE
Improve dark theme colors

### DIFF
--- a/main_engine/app.py
+++ b/main_engine/app.py
@@ -701,9 +701,9 @@ st.markdown(
 
 # Adjust style variables based on chosen Streamlit theme
 if theme == "dark":
-    st.session_state["text_color"] = "#000000"
-    st.session_state["background_color"] = "#ffff00"  # neon yellow
-    st.session_state["secondary_color"] = "#cccc00"
+    st.session_state["text_color"] = "#f0f0f0"
+    st.session_state["background_color"] = "#1e1e1e"
+    st.session_state["secondary_color"] = "#2c2c2c"
 else:
     st.session_state["text_color"] = "#000000"
     st.session_state["background_color"] = "#fffbf0"

--- a/static/style.css
+++ b/static/style.css
@@ -17,7 +17,7 @@
   --cv-accent-color: #2c2c2c;
   --btn-gold: #d4af37;
   --btn-gold-border: #d4af37;
-  --btn-text-color: #ffff00;
+  --btn-text-color: #ffffff;
 }
 
 img[src*="logo.png"] {


### PR DESCRIPTION
## Summary
- use neutral colors for dark theme in `app.py`
- update button text color in dark theme

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685670f49e5083249c20e4e30807e646