### PR TITLE
Improve theme sync for Streamlit dark mode

### DIFF
--- a/main_engine/app.py
+++ b/main_engine/app.py
@@ -695,7 +695,18 @@ initialize_app()
 # --- Apply theme from Streamlit config ---
 theme = st.get_option("theme.base") or "light"
 st.markdown(
-    f"<script>document.documentElement.setAttribute('data-theme', '{theme}');</script>",
+    f"""
+    <script>
+      const root = document.documentElement;
+      function setTheme() {{
+        const theme = window.__theme?.base || "{theme}";
+        root.setAttribute('data-theme', theme);
+      }}
+      setTheme();
+      // cập nhật khi người dùng đổi theme trên Streamlit
+      window.addEventListener('themeChanged', setTheme);
+    </script>
+    """,
     unsafe_allow_html=True,
 )
 


### PR DESCRIPTION
## Summary
- keep the `data-theme` attribute in sync with Streamlit theme changes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856773ffc088324a392fb55107fc6f8