### PR TITLE
Update theme colors

### DIFF
--- a/main_engine/app.py
+++ b/main_engine/app.py
@@ -708,14 +708,15 @@ if theme:
 
 # Adjust style variables based on chosen Streamlit theme
 if theme == "dark":
-    st.session_state["text_color"] = "#f0f0f0"
-    st.session_state["background_color"] = "#1e1e1e"
-    st.session_state["secondary_color"] = "#2c2c2c"
+    st.session_state["text_color"] = "#ffff33"
+    st.session_state["background_color"] = "#000000"
+    st.session_state["secondary_color"] = "#1e1e1e"
+    st.session_state["accent_color"] = "#ffff33"
 else:
-    st.session_state["text_color"] = "#000000"
+    st.session_state["text_color"] = "#2d1810"
     st.session_state["background_color"] = "#fffbf0"
     st.session_state["secondary_color"] = "#f4e09c"
-st.session_state["accent_color"] = "#d4af37"
+    st.session_state["accent_color"] = "#d4af37"
 
 # --- Sidebar: logo và cấu hình LLM ---
 @handle_error

--- a/static/style.css
+++ b/static/style.css
@@ -3,21 +3,21 @@
 
 /* Simple theme variables */
 :root[data-theme="light"] {
-  --cv-text-color: #000000;
+  --cv-text-color: #2d1810;
   --cv-bg-color: #fffbf0;
   --cv-accent-color: #f4e09c;
   --btn-gold: #d4af37;
   --btn-gold-border: #d4af37;
-  --btn-text-color: #000000;
+  --btn-text-color: #2d1810;
 }
 
 :root[data-theme="dark"] {
-  --cv-text-color: #f0f0f0;
-  --cv-bg-color: #1e1e1e;
-  --cv-accent-color: #2c2c2c;
-  --btn-gold: #d4af37;
-  --btn-gold-border: #d4af37;
-  --btn-text-color: #ffffff;
+  --cv-text-color: #ffff33;
+  --cv-bg-color: #000000;
+  --cv-accent-color: #1e1e1e;
+  --btn-gold: #ffff33;
+  --btn-gold-border: #ffff33;
+  --btn-text-color: #000000;
 }
 
 img[src*="logo.png"] {


### PR DESCRIPTION
## Summary
- adjust light theme for gold appearance
- add black/neon-yellow scheme for dark theme

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas and requests)*

------
https://chatgpt.com/codex/tasks/task_e_68567b316d7c8324a983212a735d5351