### PR TITLE
Introduce configurable log history limit

### DIFF
--- a/main_engine/app.py
+++ b/main_engine/app.py
@@ -54,6 +54,7 @@ try:
         EMAIL_USER,
         EMAIL_PASS,
         EMAIL_UNSEEN_ONLY,
+        LOG_HISTORY_LIMIT,
     )
     from modules.auto_fetcher import watch_loop
     
@@ -150,8 +151,8 @@ class StreamlitLogHandler(logging.Handler):
             logs = safe_session_state_get("logs", [])
             
             # Limit log size to prevent memory issues
-            if len(logs) > 500:
-                logs = logs[-400:]  # Keep last 400 entries
+            if len(logs) > LOG_HISTORY_LIMIT:
+                logs = logs[-LOG_HISTORY_LIMIT:]
                 
             logs.append({
                 "timestamp": datetime.now().strftime("%H:%M:%S"),

--- a/modules/config.py
+++ b/modules/config.py
@@ -82,6 +82,19 @@ ATTACHMENT_DIR = _clean_path("ATTACHMENT_DIR", "attachments")
 OUTPUT_CSV = _clean_path("OUTPUT_CSV", "csv/cv_summary.csv")
 # File lưu log hội thoại chat
 CHAT_LOG_FILE = _clean_path("CHAT_LOG_FILE", "log/chat_log.json")
+# Giới hạn số lượng log lưu trong Session state
+def _get_int(varname: str, default: int) -> int:
+    raw = os.getenv(varname)
+    if raw is None:
+        return default
+    cleaned = raw.split('#', 1)[0].strip()
+    try:
+        return int(cleaned)
+    except ValueError:
+        logger.warning(f"Invalid integer for {varname}: {cleaned}, using {default}")
+        return default
+
+LOG_HISTORY_LIMIT: int = _get_int("LOG_HISTORY_LIMIT", 500)
 # tạo thư mục nếu chưa tồn tại
 ATTACHMENT_DIR.mkdir(parents=True, exist_ok=True)
 OUTPUT_CSV.parent.mkdir(parents=True, exist_ok=True)

--- a/readme.md
+++ b/readme.md
@@ -153,6 +153,7 @@ python3 scripts/cli_agent.py chat "Câu hỏi của bạn"
 Lệnh `chat` tự động sử dụng khóa API tương ứng với `LLM_PROVIDER`
 được khai báo trong file `.env` (`GOOGLE_API_KEY` hoặc `OPENROUTER_API_KEY`).
 Mỗi lần hỏi đáp sẽ được lưu vào file log tại `log/chat_log.json` (có thể thay đổi qua biến `CHAT_LOG_FILE`).
+Giới hạn số log hiển thị trong giao diện Streamlit có thể chỉnh bằng biến `LOG_HISTORY_LIMIT` (mặc định 500).
 
 ## 🌐 Giao diện web (Streamlit)
 


### PR DESCRIPTION
## Summary
- add `LOG_HISTORY_LIMIT` to config with optional env var
- truncate logs using this constant in Streamlit handler
- document the new setting in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68568199d6fc83249ab011c7aa43d94b