### PR TITLE
Add FastAPI and dynamic LLM client tests

### DIFF
--- a/test/test_dynamic_llm_client.py
+++ b/test/test_dynamic_llm_client.py
@@ -1,0 +1,67 @@
+import sys
+import os
+import types
+import importlib
+import pytest
+
+# Ensure repo root in path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+# Provide dummy streamlit before importing the module
+sys.modules['streamlit'] = types.SimpleNamespace(session_state={})
+
+import modules.dynamic_llm_client as dlc
+
+
+class DummyResp:
+    def __init__(self, status_code=200, data=None):
+        self.status_code = status_code
+        self._data = data or {}
+    def json(self):
+        return self._data
+
+
+def test_provider_selection_param(monkeypatch):
+    monkeypatch.setattr(dlc.requests, "get", lambda *a, **k: DummyResp())
+    client = dlc.DynamicLLMClient(provider="openrouter", model="m1", api_key="sk-or-key")
+    assert client.provider == "openrouter"
+    assert client.model == "m1"
+    assert client.api_key == "sk-or-key"
+    assert client.client is None
+
+
+def test_provider_selection_session(monkeypatch):
+    dlc.st.session_state.clear()
+    dlc.st.session_state.update({
+        "selected_provider": "openrouter",
+        "selected_model": "m2",
+        "openrouter_api_key": "sk-or-session"
+    })
+    monkeypatch.setattr(dlc, "_streamlit_ctx_exists", lambda: True)
+    monkeypatch.setattr(dlc.requests, "get", lambda *a, **k: DummyResp())
+    client = dlc.DynamicLLMClient()
+    assert client.provider == "openrouter"
+    assert client.model == "m2"
+    assert client.api_key == "sk-or-session"
+
+
+def test_invalid_provider(monkeypatch):
+    with pytest.raises(ValueError):
+        dlc.DynamicLLMClient(provider="bad", api_key="dummy")
+
+
+def test_openrouter_unauthorized(monkeypatch):
+    monkeypatch.setattr(dlc.requests, "get", lambda *a, **k: DummyResp())
+    def fake_post(*a, **k):
+        return DummyResp(status_code=401, data={"detail": "unauthorized"})
+    monkeypatch.setattr(dlc.requests, "post", fake_post)
+    client = dlc.DynamicLLMClient(provider="openrouter", api_key="sk-or-key")
+    with pytest.raises(ValueError):
+        client.generate_content(["hi"])
+
+
+def test_openrouter_missing_key(monkeypatch):
+    monkeypatch.setattr(dlc.requests, "get", lambda *a, **k: DummyResp())
+    with pytest.raises(ValueError):
+        dlc.DynamicLLMClient(provider="openrouter", api_key="")
+

--- a/test/test_mcp_server.py
+++ b/test/test_mcp_server.py
@@ -1,0 +1,95 @@
+import sys
+import os
+import types
+import importlib
+import pandas as pd
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+# minimal env so Settings can initialize
+os.environ.setdefault("EMAIL_HOST", "host")
+os.environ.setdefault("EMAIL_PORT", "993")
+os.environ.setdefault("EMAIL_USER", "user")
+os.environ.setdefault("EMAIL_PASS", "pass")
+os.environ.setdefault("ATTACHMENT_DIR", "attachments")
+os.environ.setdefault("OUTPUT_CSV", "csv/out.csv")
+
+import modules.mcp_server as mcp
+
+
+class DummyFetcher:
+    def __init__(self, *a, **k):
+        pass
+    def connect(self):
+        pass
+
+class DummyProcessor:
+    def __init__(self, *a, **k):
+        pass
+    def process(self):
+        return pd.DataFrame([{"a": 1}])
+    def save_to_csv(self, df, path):
+        self.saved = path
+    def extract_text(self, path):
+        return "text"
+    def extract_info_with_llm(self, text):
+        return {"ok": True}
+
+
+def setup_app(monkeypatch, tmp_path):
+    monkeypatch.setattr(mcp, "EmailFetcher", DummyFetcher)
+    monkeypatch.setattr(mcp, "CVProcessor", DummyProcessor)
+    monkeypatch.setattr(mcp, "LLMClient", lambda: None)
+    monkeypatch.setattr(mcp.settings, "attachment_dir", tmp_path)
+    monkeypatch.setattr(mcp.settings, "output_csv", tmp_path / "out.csv")
+    return TestClient(mcp.app)
+
+
+def test_health_endpoint():
+    client = TestClient(mcp.app)
+    res = client.get("/")
+    assert res.status_code == 200
+    assert res.json() == {"status": "ok"}
+
+
+def test_run_full_missing_credentials(monkeypatch, tmp_path):
+    monkeypatch.setattr(mcp.settings, "email_user", "")
+    monkeypatch.setattr(mcp.settings, "email_pass", "")
+    client = setup_app(monkeypatch, tmp_path)
+    res = client.post("/run-full-process")
+    assert res.status_code == 400
+
+
+def test_run_full_success(monkeypatch, tmp_path):
+    monkeypatch.setattr(mcp.settings, "email_user", "u")
+    monkeypatch.setattr(mcp.settings, "email_pass", "p")
+    client = setup_app(monkeypatch, tmp_path)
+    res = client.post("/run-full-process")
+    assert res.status_code == 200
+    assert res.json() == {"processed": 1}
+
+
+def test_process_single_cv(monkeypatch, tmp_path):
+    monkeypatch.setattr(mcp.settings, "email_user", "u")
+    monkeypatch.setattr(mcp.settings, "email_pass", "p")
+    client = setup_app(monkeypatch, tmp_path)
+    file_content = b"data"
+    res = client.post("/process-single-cv", files={"file": ("cv.pdf", file_content, "application/pdf")})
+    assert res.status_code == 200
+    assert res.json() == {"ok": True}
+
+
+def test_results_endpoint(monkeypatch, tmp_path):
+    client = setup_app(monkeypatch, tmp_path)
+    # not exists
+    res = client.get("/results")
+    assert res.status_code == 404
+    # create file then fetch
+    out_file = tmp_path / "out.csv"
+    out_file.write_text("a,b")
+    res = client.get("/results")
+    assert res.status_code == 200
+    assert res.text == "a,b"
+


### PR DESCRIPTION
## Summary
- add FastAPI TestClient tests for mcp_server endpoints
- add dynamic_llm_client tests covering provider selection and errors
- configure fake environment and network mocks so tests don't need API keys

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685689d689048324899e4f8dbb51ed40