### PR TITLE
Add pyproject with PEP 621 metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,37 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "hoancau-ai"
+version = "0.1.0"
+description = "HoanCau AI Resume Processor"
+readme = "readme.md"
+requires-python = ">=3.10"
+license = {file = "LICENSE"}
+dependencies = [
+    "python-dotenv>=0.21.0",
+    "pdfminer.six==20231228",
+    "PyPDF2>=3.0.0",
+    "pymupdf>=1.22.0",
+    "python-docx>=0.8.11",
+    "pandas>=2.0.0",
+    "openpyxl>=3.1.0",
+    "google-generativeai>=0.2.0",
+    "requests>=2.31.0",
+    "streamlit>=1.22.0",
+    "fastapi>=0.95.0",
+    "uvicorn[standard]>=0.22.0",
+    "python-multipart>=0.0.5",
+    "click",
+    "pydantic>=2.0.0",
+    "pydantic-settings>=2.0.0",
+    "pytest>=7.0.0"
+]
+
+[project.scripts]
+cli-agent = "scripts.cli_agent:cli"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["modules*", "main_engine*"]

--- a/readme.md
+++ b/readme.md
@@ -71,7 +71,8 @@ HoanCau AI Resume Processor là hệ thống tự động trích xuất thông t
    source .venv/bin/activate      # Linux/Mac
    # .venv\Scripts\activate     # Windows
    pip install --upgrade pip
-   pip install -r requirements.txt
+   # Cài đặt project ở chế độ editable
+   pip install -e .
    ```
    Hoặc đơn giản chạy `./setup.sh` (macOS/Linux) hoặc `setup.cmd` (Windows)
    để tự động thực hiện các bước trên.


### PR DESCRIPTION
## Summary
- package project with `pyproject.toml`
- add CLI entry point configuration
- document installing with `pip install -e .`

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685689d6e8b48324a1b69ed654273709