### PR TITLE
Add dark mode instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -177,6 +177,17 @@ streamlit run scripts/simple_app.py
 
 Ứng dụng sẽ hướng dẫn tuần tự nhập API key → fetch CV → xử lý → xem kết quả và ẩn các tab nâng cao.
 
+### 🌙 Dark Mode
+
+Để kích hoạt giao diện nền tối cho Streamlit, hãy tạo file `.streamlit/config.toml` với nội dung:
+
+```toml
+[theme]
+base = "dark"
+```
+
+Sau khi chạy ứng dụng, bạn có thể tùy chỉnh thêm các màu sắc trong `static/style.css` nếu muốn.
+
 ## 🗂️ Cấu trúc dự án
 
 ```


### PR DESCRIPTION
## Summary
- document how to enable Streamlit dark mode with `.streamlit/config.toml`
- mention customizing `static/style.css`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68568dffe42c83248323e64771944e85