### PR TITLE
Unify log directory handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,6 +90,7 @@ ENABLE_REQUEST_LOGGING=false   # Log các API requests (tắt để bảo mật)
 
 # Cấu hình logging
 LOG_LEVEL=INFO                 # DEBUG, INFO, WARNING, ERROR
+LOG_DIR=log                   # Thư mục lưu log chung
 LOG_FILE=log/app.log          # File log
 LOG_MAX_SIZE=10MB             # Kích thước tối đa file log
 LOG_BACKUP_COUNT=5            # Số file backup

--- a/main_engine/app.py
+++ b/main_engine/app.py
@@ -13,9 +13,7 @@ ROOT = HERE.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-# Ensure log directory exists
-LOG_DIR = ROOT / "log"
-LOG_DIR.mkdir(parents=True, exist_ok=True)
+from modules.config import LOG_DIR, LOG_FILE
 
 # Khi chạy bằng `streamlit run`, __package__ sẽ là None dẫn tới lỗi khi
 # dùng relative imports. Thiết lập thủ công để các import như
@@ -35,7 +33,7 @@ logging.basicConfig(
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
     handlers=[
         logging.StreamHandler(sys.stdout),
-        logging.FileHandler(LOG_DIR / "app.log", encoding='utf-8')
+        logging.FileHandler(LOG_FILE, encoding='utf-8')
     ]
 )
 logger = logging.getLogger(__name__)

--- a/modules/cv_processor.py
+++ b/modules/cv_processor.py
@@ -21,8 +21,9 @@ stream_h = logging.StreamHandler()
 stream_h.setFormatter(fmt)
 logger.addHandler(stream_h)
 # handler xuất log ra file trong thư mục log
-Path("log").mkdir(parents=True, exist_ok=True)
-file_h = logging.FileHandler("log/cv_processor.log", encoding="utf-8")
+from .config import LOG_DIR
+LOG_DIR.mkdir(parents=True, exist_ok=True)
+file_h = logging.FileHandler(LOG_DIR / "cv_processor.log", encoding="utf-8")
 file_h.setFormatter(fmt)
 logger.addHandler(file_h)
 

--- a/readme.md
+++ b/readme.md
@@ -153,7 +153,7 @@ python3 scripts/cli_agent.py chat "Câu hỏi của bạn"
 ```
 Lệnh `chat` tự động sử dụng khóa API tương ứng với `LLM_PROVIDER`
 được khai báo trong file `.env` (`GOOGLE_API_KEY` hoặc `OPENROUTER_API_KEY`).
-Mỗi lần hỏi đáp sẽ được lưu vào file log tại `log/chat_log.json` (có thể thay đổi qua biến `CHAT_LOG_FILE`).
+Mỗi lần hỏi đáp sẽ được lưu vào file log tại `log/chat_log.json` (có thể thay đổi qua biến `CHAT_LOG_FILE` hoặc thư mục `LOG_DIR`).
 
 ## 🌐 Giao diện web (Streamlit)
 


### PR DESCRIPTION
## Summary
- centralize logging paths via `LOG_DIR` and `LOG_FILE` in `config`
- update modules to reference the new constants
- document `LOG_DIR` in `.env.example` and README
- include tracked `log/.gitkeep`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6858ab5f3bdc8324bf1d672109d29da3