### PR TITLE
Fix module import paths

### DIFF
--- a/scripts/cli_agent.py
+++ b/scripts/cli_agent.py
@@ -1,8 +1,18 @@
 import os
+import sys
 import threading
 import click
 import pandas as pd
 import uvicorn
+
+# Ensure the project `src` directory is on sys.path so that local modules can
+# be imported when running this script directly.
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+SRC_DIR = os.path.join(ROOT, "src")
+for path in (ROOT, SRC_DIR):
+    if path not in sys.path:
+        sys.path.insert(0, path)
+
 from modules.config import LLM_CONFIG
 
 from modules.auto_fetcher import watch_loop

--- a/scripts/simple_app.py
+++ b/scripts/simple_app.py
@@ -1,7 +1,17 @@
 import os
+import sys
 from pathlib import Path
 import pandas as pd
 import streamlit as st
+
+# Ensure the project's `src` directory is on sys.path so that the local
+# `modules` package can be imported when running this script directly.
+ROOT = Path(__file__).resolve().parent.parent
+SRC_DIR = ROOT / "src"
+for path in (ROOT, SRC_DIR):
+    path_str = str(path)
+    if path_str not in sys.path:
+        sys.path.insert(0, path_str)
 from modules.email_fetcher import EmailFetcher
 from modules.cv_processor import CVProcessor
 from modules.dynamic_llm_client import DynamicLLMClient
@@ -15,7 +25,6 @@ from modules.config import (
 )
 
 # Base directory of the project (one level up from this script)
-ROOT = Path(__file__).resolve().parent.parent
 STATIC_DIR = ROOT / "static"
 
 def load_css() -> None:

--- a/src/main_engine/app.py
+++ b/src/main_engine/app.py
@@ -10,8 +10,14 @@ from typing import Optional, Dict, Any
 # Đưa thư mục gốc (chứa `modules/`) vào sys.path để import modules
 HERE = Path(__file__).parent
 ROOT = HERE.parent.parent
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+# Add both the project root and the `src` directory so that imports of the
+# `modules` package succeed when this application is run directly via
+# `streamlit` or regular `python` commands.
+SRC_DIR = ROOT / "src"
+for path in (ROOT, SRC_DIR):
+    path_str = str(path)
+    if path_str not in sys.path:
+        sys.path.insert(0, path_str)
 
 from modules.config import LOG_FILE
 

--- a/src/main_engine/config_info.py
+++ b/src/main_engine/config_info.py
@@ -5,8 +5,12 @@ import sys
 # Đưa thư mục gốc (chứa `modules/`) vào sys.path
 HERE = os.path.dirname(__file__)
 ROOT = os.path.abspath(os.path.join(HERE, "..", ".."))
-if ROOT not in sys.path:
-    sys.path.insert(0, ROOT)
+# Add both project root and `src` directory so that `modules` package is
+# importable when running this module directly.
+SRC_DIR = os.path.join(ROOT, "src")
+for path in (ROOT, SRC_DIR):
+    if path not in sys.path:
+        sys.path.insert(0, path)
 
 import click                               # CLI framework
 from modules.config import LLM_CONFIG, get_model_price       # cấu hình LLM

--- a/src/main_engine/main.py
+++ b/src/main_engine/main.py
@@ -5,8 +5,12 @@ import sys
 # Đưa thư mục gốc vào sys.path để import modules
 HERE = os.path.dirname(__file__)
 ROOT = os.path.abspath(os.path.join(HERE, "..", ".."))
-if ROOT not in sys.path:
-    sys.path.insert(0, ROOT)
+# Ensure the `src` directory is on the import path so that `modules` can be
+# imported when this script is executed directly.
+SRC_DIR = os.path.join(ROOT, "src")
+for path in (ROOT, SRC_DIR):
+    if path not in sys.path:
+        sys.path.insert(0, path)
 
 import click
 import logging

--- a/src/main_engine/select_top5.py
+++ b/src/main_engine/select_top5.py
@@ -5,8 +5,12 @@ import sys
 # Đưa thư mục gốc vào sys.path để import modules
 HERE = os.path.dirname(__file__)
 ROOT = os.path.abspath(os.path.join(HERE, "..", ".."))
-if ROOT not in sys.path:
-    sys.path.insert(0, ROOT)
+# Include both the project root and `src` directory for direct execution
+# so that imports like `modules.*` resolve properly.
+SRC_DIR = os.path.join(ROOT, "src")
+for path in (ROOT, SRC_DIR):
+    if path not in sys.path:
+        sys.path.insert(0, path)
 
 import json
 import re


### PR DESCRIPTION
## Summary
- ensure `src` directory is added to `sys.path` in executables
- update Streamlit app path logic for robust imports
- keep cli scripts consistent
- adjust simple app to use same path logic

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q httpx`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858bf4df7fc8324bb7e098563a6ebd0