### PR TITLE
Ensure log folder exists before configuring logging

### DIFF
--- a/src/main_engine/app.py
+++ b/src/main_engine/app.py
@@ -21,6 +21,9 @@ for path in (ROOT, SRC_DIR):
 
 from modules.config import LOG_FILE
 
+# Ensure log directory exists even if configuration hasn't created it yet
+LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+
 # Khi chạy bằng `streamlit run`, __package__ sẽ là None dẫn tới lỗi khi
 # dùng relative imports. Thiết lập thủ công để các import như
 # `from .tabs import fetch_tab` hoạt động.


### PR DESCRIPTION
## Summary
- create log directory defensively in `main_engine/app.py` before configuring logging

## Testing
- `pip install -r requirements.txt`
- `pip install httpx`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6858ca3279a48324bded9d4a90ca7b28