### PR TITLE
Add time-aware chatbot feature

### DIFF
--- a/src/modules/qa_chatbot.py
+++ b/src/modules/qa_chatbot.py
@@ -94,6 +94,16 @@ def _classify_question(question: str) -> str:
         return "general"
 
 
+def _is_time_question(question: str) -> bool:
+    """Detect if the user is asking about current time or date."""
+    question_lower = question.lower()
+    patterns = [
+        r"bây giờ", r"mấy giờ", r"thời gian hiện tại", r"current time",
+        r"current date", r"ngày bao nhiêu", r"hôm nay" 
+    ]
+    return any(re.search(p, question_lower) for p in patterns)
+
+
 def _create_enhanced_prompt(question: str, df: pd.DataFrame, context: Optional[Dict[str, Any]] = None) -> list:
     """Create enhanced prompt with better context and instructions."""
     
@@ -149,6 +159,13 @@ def answer_question(question: str, df: pd.DataFrame, provider: str, model: str, 
     
     question = question.strip()
     logger.info(f"Processing question: {question[:100]}... (Total records: {len(df)})")
+
+    # Return system time immediately if asked
+    if _is_time_question(question):
+        now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        answer = f"Bây giờ là {now}"
+        _log_chat(question, answer)
+        return answer
     
     try:
         # Create enhanced prompt

--- a/test/test_time_question.py
+++ b/test/test_time_question.py
@@ -1,0 +1,22 @@
+import os
+import sys
+from pathlib import Path
+import pandas as pd
+import types
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / 'src'))
+
+import modules.qa_chatbot as qc
+
+
+def test_time_question(monkeypatch):
+    # Fail if LLM client is created
+    class FailClient:
+        def __init__(self, *a, **k):
+            raise AssertionError('LLM should not be called')
+    monkeypatch.setattr(qc, 'DynamicLLMClient', FailClient)
+    df = pd.DataFrame([{'a':1}])
+    ans = qc.answer_question('Bây giờ là mấy giờ?', df, provider='p', model='m', api_key='key')
+    assert 'Bây giờ là' in ans


### PR DESCRIPTION
## Summary
- detect time-related queries in `qa_chatbot`
- return current timestamp instead of calling the LLM
- test that time questions bypass the LLM

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859222792008324b35fe11e15161d56