### PR TITLE
Improve Excel output with clickable links

### DIFF
--- a/scripts/cli_agent.py
+++ b/scripts/cli_agent.py
@@ -55,7 +55,10 @@ def full_process(unseen_only):
         click.echo("Không có CV mới để xử lý.")
     else:
         processor.save_to_csv(df, str(settings.output_csv))
-        click.echo(f"Đã xử lý {len(df)} CV và lưu vào {settings.output_csv}")
+        processor.save_to_excel(df, str(settings.output_excel))
+        click.echo(
+            f"Đã xử lý {len(df)} CV và lưu vào {settings.output_csv} & {settings.output_excel}"
+        )
 
 @cli.command()
 @click.argument('file', type=click.Path(exists=True))

--- a/scripts/simple_app.py
+++ b/scripts/simple_app.py
@@ -18,6 +18,7 @@ from modules.dynamic_llm_client import DynamicLLMClient
 from modules.config import (
     ATTACHMENT_DIR,
     OUTPUT_CSV,
+    OUTPUT_EXCEL,
     EMAIL_HOST,
     EMAIL_PORT,
     LLM_PROVIDER,
@@ -106,7 +107,10 @@ if st.button("Process CV"):
             progress.progress(idx / total)
         df = pd.DataFrame(results)
         processor.save_to_csv(df, str(OUTPUT_CSV))
-        st.success(f"Đã xử lý {len(df)} CV. Kết quả lưu ở {OUTPUT_CSV}")
+        processor.save_to_excel(df, str(OUTPUT_EXCEL))
+        st.success(
+            f"Đã xử lý {len(df)} CV. Kết quả lưu ở {OUTPUT_CSV} và {OUTPUT_EXCEL}"
+        )
 
 # --- View results ---
 st.header("Xem kết quả")
@@ -119,5 +123,13 @@ if OUTPUT_CSV.exists():
         file_name=OUTPUT_CSV.name,
         mime="text/csv",
     )
+    if OUTPUT_EXCEL.exists():
+        with open(OUTPUT_EXCEL, "rb") as f:
+            st.download_button(
+                "Tải Excel",
+                f.read(),
+                file_name=OUTPUT_EXCEL.name,
+                mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            )
 else:
     st.info("Chưa có kết quả để hiển thị.")

--- a/src/main_engine/tabs/process_tab.py
+++ b/src/main_engine/tabs/process_tab.py
@@ -4,7 +4,7 @@ import pandas as pd
 import streamlit as st
 
 from modules.cv_processor import CVProcessor
-from modules.config import ATTACHMENT_DIR, OUTPUT_CSV, get_model_price
+from modules.config import ATTACHMENT_DIR, OUTPUT_CSV, OUTPUT_EXCEL, get_model_price
 from modules.dynamic_llm_client import DynamicLLMClient
 
 
@@ -70,5 +70,8 @@ def render(provider: str, model: str, api_key: str) -> None:
                 ],
             )
             processor.save_to_csv(df, str(OUTPUT_CSV))
+            processor.save_to_excel(df, str(OUTPUT_EXCEL))
             logging.info(f"Đã xử lý {len(df)} CV và lưu kết quả")
-            st.success(f"Đã xử lý {len(df)} CV và lưu vào `{OUTPUT_CSV.name}`.")
+            st.success(
+                f"Đã xử lý {len(df)} CV và lưu vào `{OUTPUT_CSV.name}` và `{OUTPUT_EXCEL.name}`."
+            )

--- a/src/main_engine/tabs/results_tab.py
+++ b/src/main_engine/tabs/results_tab.py
@@ -3,7 +3,7 @@ import os
 import pandas as pd
 import streamlit as st
 
-from modules.config import ATTACHMENT_DIR, OUTPUT_CSV
+from modules.config import ATTACHMENT_DIR, OUTPUT_CSV, OUTPUT_EXCEL
 
 
 def render() -> None:
@@ -31,5 +31,14 @@ def render() -> None:
             mime="text/csv",
             help="Lưu kết quả phân tích về máy",
         )
+        if os.path.exists(OUTPUT_EXCEL):
+            with open(OUTPUT_EXCEL, "rb") as f:
+                st.download_button(
+                    label="Tải xuống Excel",
+                    data=f.read(),
+                    file_name=OUTPUT_EXCEL.name,
+                    mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                    help="File Excel kèm link tới CV gốc",
+                )
     else:
         st.info("Chưa có kết quả. Vui lòng chạy Batch hoặc Single.")

--- a/src/modules/config.py
+++ b/src/modules/config.py
@@ -91,11 +91,13 @@ LOG_FILE = _clean_path("LOG_FILE", str(LOG_DIR / "app.log"))
 
 ATTACHMENT_DIR = _clean_path("ATTACHMENT_DIR", "attachments")
 OUTPUT_CSV = _clean_path("OUTPUT_CSV", "csv/cv_summary.csv")
+OUTPUT_EXCEL = _clean_path("OUTPUT_EXCEL", "excel/cv_summary.xlsx")
 # File lưu log hội thoại chat
 CHAT_LOG_FILE = _clean_path("CHAT_LOG_FILE", str(LOG_DIR / "chat_log.json"))
 # tạo thư mục nếu chưa tồn tại
 ATTACHMENT_DIR.mkdir(parents=True, exist_ok=True)
 OUTPUT_CSV.parent.mkdir(parents=True, exist_ok=True)
+OUTPUT_EXCEL.parent.mkdir(parents=True, exist_ok=True)
 LOG_DIR.mkdir(parents=True, exist_ok=True)
 CHAT_LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
 LOG_FILE.parent.mkdir(parents=True, exist_ok=True)

--- a/src/modules/mcp_server.py
+++ b/src/modules/mcp_server.py
@@ -30,6 +30,7 @@ class Settings(BaseSettings):
     email_pass: str        # mật khẩu/app-password email
     attachment_dir: Path   # thư mục lưu tệp đính kèm
     output_csv: Path       # đường dẫn file CSV xuất kết quả
+    output_excel: Path     # đường dẫn file Excel xuất kết quả
     email_unseen_only: bool = True  # chỉ quét email chưa đọc nếu True
     platform_api_key: str | None = None  # API key cho các platform (tùy chọn)
 
@@ -41,6 +42,7 @@ settings = Settings()
 settings.attachment_dir.mkdir(parents=True, exist_ok=True)
 # Đảm bảo thư mục chứa file kết quả tồn tại
 settings.output_csv.parent.mkdir(parents=True, exist_ok=True)
+settings.output_excel.parent.mkdir(parents=True, exist_ok=True)
 
 # Cấu hình logging cho toàn ứng dụng
 logging.basicConfig(
@@ -94,6 +96,7 @@ async def run_full():
 
     # Lưu DataFrame vào CSV, ghi đè file cũ
     processor.save_to_csv(df, str(settings.output_csv))
+    processor.save_to_excel(df, str(settings.output_excel))
     return {"processed": len(df)}
 
 

--- a/test/test_cli_agent.py
+++ b/test/test_cli_agent.py
@@ -47,6 +47,8 @@ def cli_module(monkeypatch, tmp_path):
             return DummyDF(calls.get('df_rows', []))
         def save_to_csv(self, df, path):
             calls['saved'] = path
+        def save_to_excel(self, df, path):
+            calls['saved_excel'] = path
         def extract_text(self, f):
             calls['extract_text'] = f
             return 'text'
@@ -84,7 +86,8 @@ def cli_module(monkeypatch, tmp_path):
         email_user='u',
         email_pass='pw',
         email_unseen_only=True,
-        output_csv=tmp_path / 'out.csv'
+        output_csv=tmp_path / 'out.csv',
+        output_excel=tmp_path / 'out.xlsx'
     )
     monkeypatch.setitem(sys.modules, 'modules.mcp_server', types.SimpleNamespace(settings=settings))
 

--- a/test/test_mcp_server.py
+++ b/test/test_mcp_server.py
@@ -17,6 +17,7 @@ os.environ.setdefault("EMAIL_USER", "user")
 os.environ.setdefault("EMAIL_PASS", "pass")
 os.environ.setdefault("ATTACHMENT_DIR", "attachments")
 os.environ.setdefault("OUTPUT_CSV", "csv/out.csv")
+os.environ.setdefault("OUTPUT_EXCEL", "excel/out.xlsx")
 
 import modules.mcp_server as mcp
 
@@ -34,6 +35,8 @@ class DummyProcessor:
         return pd.DataFrame([{"a": 1}])
     def save_to_csv(self, df, path):
         self.saved = path
+    def save_to_excel(self, df, path):
+        self.saved_excel = path
     def extract_text(self, path):
         return "text"
     def extract_info_with_llm(self, text):


### PR DESCRIPTION
## Summary
- add `OUTPUT_EXCEL` path in configuration and ensure directory
- support saving DataFrame to Excel with styling and hyperlinks
- update CLI, Streamlit apps and MCP server to generate Excel
- allow downloading Excel results in Streamlit
- adjust tests for new Excel behavior

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q httpx`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859f8e6bb0083248a0e12f7d40c2030

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Processed CV data can now be saved and downloaded in both CSV and Excel formats.
  - Added download buttons for Excel files alongside CSV files in the user interface.
  - Excel output includes improved formatting and clickable links for easier navigation.

- **Bug Fixes**
  - None.

- **Tests**
  - Updated tests to support and verify Excel file output functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->