### PR TITLE
Improve results table layout & file links

### DIFF
--- a/src/main_engine/tabs/results_tab.py
+++ b/src/main_engine/tabs/results_tab.py
@@ -13,8 +13,21 @@ def render() -> None:
         df = pd.read_csv(OUTPUT_CSV, encoding="utf-8-sig")
 
         def make_link(fname: str) -> str:
+            """Create a safe link that works across browsers."""
             path = (ATTACHMENT_DIR / fname).resolve()
-            return f'<a href="file://{path}" target="_blank">{fname}</a>'
+            if not path.exists():
+                return fname
+            import base64
+
+            data = base64.b64encode(path.read_bytes()).decode()
+            mime = (
+                "application/pdf"
+                if path.suffix.lower() == ".pdf"
+                else "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+            )
+            return (
+                f'<a download="{fname}" href="data:{mime};base64,{data}">{fname}</a>'
+            )
 
         if "Nguồn" in df.columns:
             df["Nguồn"] = df["Nguồn"].apply(make_link)

--- a/static/style.css
+++ b/static/style.css
@@ -28,7 +28,7 @@ img[src*="logo.png"] {
 body {
   background-color: var(--cv-bg-color) !important;
   color: var(--cv-text-color) !important;
-  font-size: 1.05rem;
+  font-size: 0.95rem;
   font-family: 'Be Vietnam Pro', sans-serif;
 }
 
@@ -91,4 +91,13 @@ div[data-testid="stDataFrame"] td {
   white-space: pre-wrap !important;
   word-break: break-word !important;
   max-width: 300px;
+}
+
+/* Compact result table */
+table.dataframe {
+  font-size: 0.85rem;
+}
+table.dataframe th,
+table.dataframe td {
+  padding: 4px 6px;
 }


### PR DESCRIPTION
## Summary
- link results to attachments via base64 for better browser support
- reduce default font size and add compact table styling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859fc068b0483248dd373c437efea70