### PR TITLE
Force light theme

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,2 @@
+[theme]
+base = "light"

--- a/readme.md
+++ b/readme.md
@@ -208,14 +208,7 @@ streamlit run scripts/simple_app.py
 
 ### 🌙 Dark Mode
 
-Để kích hoạt giao diện nền tối cho Streamlit, hãy tạo file `.streamlit/config.toml` với nội dung:
-
-```toml
-[theme]
-base = "dark"
-```
-
-Sau khi chạy ứng dụng, bạn có thể tùy chỉnh thêm các màu sắc trong `static/style.css` nếu muốn.
+Ứng dụng hiện luôn sử dụng giao diện sáng (light theme) để đảm bảo trải nghiệm thống nhất. Nếu muốn bật chế độ tối, bạn cần tự chỉnh sửa mã nguồn.
 
 ## 🗂️ Cấu trúc dự án
 

--- a/src/main_engine/app.py
+++ b/src/main_engine/app.py
@@ -724,9 +724,10 @@ def initialize_app():
 initialize_app()
 
 # --- Apply theme from Streamlit config ---
-theme = st.get_option("theme.base") or "light"
+# Always force light theme for a consistent look
+theme = "light"
 st.markdown(
-    f"<script>document.documentElement.setAttribute('data-theme', '{theme}');</script>",
+    "<script>document.documentElement.setAttribute('data-theme', 'light');</script>",
     unsafe_allow_html=True,
 )
 

--- a/test/test_theme_dark.py
+++ b/test/test_theme_dark.py
@@ -92,10 +92,10 @@ def _install_app(monkeypatch):
     return mod
 
 
-def _css_dark_values():
+def _css_light_values():
     css = (Path(__file__).resolve().parents[1] / "static" / "style.css").read_text()
-    m = re.search(r':root\[data-theme="dark"\]\s*{([^}]*)}', css, re.M)
-    assert m, "dark theme section missing"
+    m = re.search(r':root\[data-theme="light"\]\s*{([^}]*)}', css, re.M)
+    assert m, "light theme section missing"
     body = m.group(1)
     def g(var):
         m2 = re.search(rf'--{var}:\s*([^;]+);', body)
@@ -108,8 +108,8 @@ def _css_dark_values():
     }
 
 
-def test_dark_theme_session_state(monkeypatch):
+def test_theme_forced_light(monkeypatch):
     app = _install_app(monkeypatch)
-    expected = _css_dark_values()
+    expected = _css_light_values()
     for k, v in expected.items():
         assert app.st.session_state[k] == v


### PR DESCRIPTION
## Summary
- force light theme regardless of Streamlit setting
- clarify dark mode note in README
- update test to verify forced light theme
- add `.streamlit/config.toml` defaulting to light

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a221a21588324b01ebf518a40d66f