### PR TITLE
Add env update script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
 
 [project.scripts]
 cli-agent = "scripts.cli_agent:cli"
+env-update = "scripts.update_env:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/readme.md
+++ b/readme.md
@@ -91,7 +91,8 @@ tạo các thư mục cần thiết.
    cp .env.example .env
    ```
    Sau đó mở `.env` bằng editor bất kỳ và thay thế các giá trị placeholder
-   (như `your_google_api_key`) bằng thông tin thực tế. Những biến quan trọng gồm:
+   (như `your_google_api_key`) bằng thông tin thực tế hoặc chạy
+   `python scripts/update_env.py` để nhập giá trị trực tiếp. Những biến quan trọng gồm:
    `LLM_PROVIDER`, `LLM_MODEL`, một trong các khóa API (`GOOGLE_API_KEY` hoặc
    `OPENROUTER_API_KEY`), `EMAIL_USER` và `EMAIL_PASS`. File `.env` đã nằm trong
    `.gitignore` nên **không commit** lên Git. Nếu gặp lỗi cấu hình, hãy so sánh

--- a/scripts/update_env.py
+++ b/scripts/update_env.py
@@ -1,0 +1,48 @@
+import os
+import shutil
+import click
+from dotenv import load_dotenv, set_key, get_key
+
+@click.command()
+@click.option('--env-file', default='.env', help='Đường dẫn tới file .env')
+@click.option('--create-from-example', is_flag=True,
+              help='Tạo file .env từ .env.example nếu chưa tồn tại')
+@click.option('--set', 'kv_pairs', multiple=True,
+              help='Cặp KEY=VALUE để thiết lập (có thể lặp lại)')
+def main(env_file, create_from_example, kv_pairs):
+    """Cập nhật file .env dựa trên input người dùng."""
+    if not os.path.exists(env_file):
+        if create_from_example and os.path.exists('.env.example'):
+            shutil.copy('.env.example', env_file)
+            click.echo(f'Đã tạo {env_file} từ .env.example')
+        else:
+            open(env_file, 'a').close()
+            click.echo(f'Đã tạo file trống {env_file}')
+
+    load_dotenv(env_file)
+
+    updates = {}
+    for pair in kv_pairs:
+        if '=' not in pair:
+            raise click.BadParameter('--set phải theo dạng KEY=VALUE')
+        key, value = pair.split('=', 1)
+        updates[key.strip()] = value
+
+    if not updates:
+        click.echo('Nhập tên biến trống để kết thúc.')
+        while True:
+            key = click.prompt('Biến', default='', show_default=False)
+            if not key:
+                break
+            default = os.getenv(key) or get_key(env_file, key) or ''
+            value = click.prompt('Giá trị', default=default, show_default=bool(default))
+            updates[key] = value
+
+    for key, value in updates.items():
+        set_key(env_file, key, value)
+        click.echo(f'Đã đặt {key}')
+
+    click.echo('Hoàn tất cập nhật môi trường.')
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add a utility script `scripts/update_env.py` to update `.env`
- expose the script as `env-update` CLI entry point
- document how to use the script in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a25f8fb2c8324b93d1465f1f4440c