### PR TITLE
Add .env editor tab

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -196,6 +196,7 @@ Truy cập `http://localhost:8501` để:
 - Xử lý batch, xử lý đơn, xem CSV và chat với AI.
 - Trong tab **MCP Server**, nhập API key (Google/OpenRouter/VectorShift) và nhấn
   "Khởi động" để server tự nhận diện platform.
+- Tab **Chỉnh .env** cho phép xem và lưu nội dung file cấu hình ngay trên giao diện.
 
 ### 🚲 Simple Mode
 

--- a/src/main_engine/app.py
+++ b/src/main_engine/app.py
@@ -70,6 +70,7 @@ try:
             process_tab,
             single_tab,
             results_tab,
+            env_tab,
         )
         # Import chat_tab only if exists, otherwise use built-in
         try:
@@ -1115,14 +1116,15 @@ custom_css = f"""
 
 st.markdown(custom_css, unsafe_allow_html=True)
 
-# --- Main UI: 3 Tabs ---
-tab_fetch, tab_process, tab_single, tab_results, tab_chat = st.tabs(
+# --- Main UI Tabs ---
+tab_fetch, tab_process, tab_single, tab_results, tab_chat, tab_env = st.tabs(
     [
         "Lấy CV từ Email",
         "Xử lý CV",
         "Single File",
         "Kết quả",
         "Hỏi AI",
+        "Chỉnh .env",
     ]
 )
 
@@ -1140,6 +1142,9 @@ with tab_results:
 
 with tab_chat:
     render_enhanced_chat_tab()
+
+with tab_env:
+    env_tab.render(ROOT)
 
 
 # --- Footer ---

--- a/src/main_engine/tabs/env_tab.py
+++ b/src/main_engine/tabs/env_tab.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+import streamlit as st
+from dotenv import load_dotenv
+
+
+def render(root: Path) -> None:
+    """Render UI for editing the .env file."""
+    st.subheader("Chỉnh sửa file .env")
+
+    env_path = root / ".env"
+    if not env_path.exists():
+        st.info("Chưa có file .env, sẽ tạo mới khi lưu.")
+        env_text = ""
+    else:
+        try:
+            env_text = env_path.read_text(encoding="utf-8")
+        except Exception as e:
+            st.error(f"Không thể đọc file .env: {e}")
+            env_text = ""
+
+    env_content = st.text_area("Nội dung .env", value=env_text, height=400, key="env_editor")
+
+    col1, col2 = st.columns(2)
+    with col1:
+        if st.button("Lưu .env"):
+            try:
+                env_path.write_text(env_content, encoding="utf-8")
+                load_dotenv(env_path, override=True)
+                st.success("Đã lưu file .env")
+            except Exception as e:
+                st.error(f"Lỗi khi lưu file .env: {e}")
+
+    with col2:
+        if st.button("Tải lại") and env_path.exists():
+            try:
+                refreshed = env_path.read_text(encoding="utf-8")
+                st.session_state.env_editor = refreshed
+                st.info("Đã tải lại nội dung từ file")
+            except Exception as e:
+                st.error(f"Lỗi tải lại file .env: {e}")
+


### PR DESCRIPTION
## Summary
- add env_tab.py for editing `.env`
- integrate new tab into Streamlit app
- mention new feature in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_685a2891d5c4832489631bd2491585fb