### PR TITLE
Add scrollable container to results table

### DIFF
--- a/src/main_engine/tabs/results_tab.py
+++ b/src/main_engine/tabs/results_tab.py
@@ -32,10 +32,13 @@ def render() -> None:
         if "Nguồn" in df.columns:
             df["Nguồn"] = df["Nguồn"].apply(make_link)
 
-        st.markdown(
-            df.to_html(escape=False, index=False),
-            unsafe_allow_html=True,
+        table_html = df.to_html(escape=False, index=False)
+        styled_html = (
+            "<div style='max-height: 500px; overflow-y: auto; overflow-x: auto;'>"
+            f"{table_html}"
+            "</div>"
         )
+        st.markdown(styled_html, unsafe_allow_html=True)
         csv_bytes = df.to_csv(index=False, encoding="utf-8-sig").encode()
         st.download_button(
             label="Tải xuống CSV",


### PR DESCRIPTION
## Summary
- wrap results table in a scrollable div so long CSVs remain compact

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q httpx`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a290d7e6c8324b5be7dda5135a24c