### PR TITLE
Improve email fetch tab

### DIFF
--- a/src/main_engine/app.py
+++ b/src/main_engine/app.py
@@ -65,24 +65,25 @@ try:
     from modules.auto_fetcher import watch_loop
     
     try:
-        from .tabs import (
-            fetch_tab,
-            process_tab,
-            single_tab,
-            results_tab,
-            env_tab,
-        )
-        # Import chat_tab only if exists, otherwise use built-in
-        try:
-            from .tabs import chat_tab  # noqa: F401
-            HAS_EXTERNAL_CHAT_TAB = True
-        except ImportError:
-            HAS_EXTERNAL_CHAT_TAB = False
-            logger.info("Using built-in chat tab implementation")
+        from .tabs import fetch_tab, process_tab, single_tab, results_tab
     except ImportError as ie:
-        logger.warning(f"Some tab imports failed: {ie}")
-        # Set fallback flags
+        logger.error(f"Failed to import core tabs: {ie}")
+        st.error(f"Lỗi import tabs: {ie}")
+        st.stop()
+
+    try:
+        from .tabs import env_tab
+    except ImportError:
+        logger.warning("env_tab not available; .env editing disabled")
+        import types
+        env_tab = types.SimpleNamespace(render=lambda *a, **k: None)
+
+    try:
+        from .tabs import chat_tab  # noqa: F401
+        HAS_EXTERNAL_CHAT_TAB = True
+    except ImportError:
         HAS_EXTERNAL_CHAT_TAB = False
+        logger.info("Using built-in chat tab implementation")
 except ImportError as e:
     logger.error(f"Failed to import modules: {e}")
     st.error(f"Lỗi import modules: {e}")

--- a/src/main_engine/tabs/fetch_tab.py
+++ b/src/main_engine/tabs/fetch_tab.py
@@ -1,5 +1,6 @@
 import logging
 from typing import List
+from pathlib import Path
 import streamlit as st
 
 from modules.config import ATTACHMENT_DIR, EMAIL_HOST, EMAIL_PORT
@@ -28,8 +29,18 @@ def render(email_user: str, email_pass: str, unseen_only: bool) -> None:
                 st.write(new_files)
             else:
                 st.info("Không có file đính kèm mới.")
-        attachments = [str(p) for p in ATTACHMENT_DIR.glob("*")]
-        st.write(attachments)
+        attachments = sorted(ATTACHMENT_DIR.glob("*"))
+        if attachments:
+            items = "".join(f"<li>{Path(p).name}</li>" for p in attachments)
+            list_html = f"<ul>{items}</ul>"
+            styled_html = (
+                "<div style='max-height: 400px; overflow-y: auto; overflow-x: auto;'>"
+                f"{list_html}"
+                "</div>"
+            )
+            st.markdown(styled_html, unsafe_allow_html=True)
+        else:
+            st.info("Chưa có CV nào được tải về.")
     if st.button("Xóa toàn bộ attachments", help="Xoá tất cả file đã tải"):
         st.session_state.confirm_delete = True
     if st.session_state.get("confirm_delete"):


### PR DESCRIPTION
## Summary
- allow missing env_tab to fallback to stub to avoid import errors
- display fetched CV attachments inside a scrollable div

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a2ace86708324941b1ddde3683cef