### PR TITLE
Clean up unused imports

### DIFF
--- a/scripts/cli_agent.py
+++ b/scripts/cli_agent.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import threading
 import click
 import pandas as pd
 import uvicorn

--- a/scripts/health_check.py
+++ b/scripts/health_check.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import importlib
 from pathlib import Path

--- a/test/test_dynamic_llm_client.py
+++ b/test/test_dynamic_llm_client.py
@@ -1,7 +1,6 @@
 import sys
 import os
 import types
-import importlib
 import pytest
 
 # Ensure repo root and src in path

--- a/test/test_email_fetcher.py
+++ b/test/test_email_fetcher.py
@@ -2,7 +2,6 @@ import sys
 import os
 import types
 from email.message import EmailMessage
-from pathlib import Path
 
 import importlib
 import pytest

--- a/test/test_mcp_server.py
+++ b/test/test_mcp_server.py
@@ -1,9 +1,6 @@
 import sys
 import os
-import types
-import importlib
 import pandas as pd
-import pytest
 from fastapi.testclient import TestClient
 
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))

--- a/test/test_time_question.py
+++ b/test/test_time_question.py
@@ -1,8 +1,6 @@
-import os
 import sys
 from pathlib import Path
 import pandas as pd
-import types
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))


### PR DESCRIPTION
## Summary
- clean up unused imports in CLI and health check scripts
- drop unused imports from tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a30227e148324917444dc7e3fdf8e