### PR TITLE
Fix chatbot output in Hỏi AI tab

### DIFF
--- a/src/main_engine/tabs/chat_tab.py
+++ b/src/main_engine/tabs/chat_tab.py
@@ -38,7 +38,9 @@ def render(provider: str, model: str, api_key: str) -> None:
                 try:
                     logging.info("Đang gửi câu hỏi tới AI")
                     answer = chatbot.ask_question(question, df)
-                    st.markdown(answer)
+                    # Allow basic HTML in the answer so line breaks and lists
+                    # from the LLM render correctly in Streamlit.
+                    st.markdown(answer, unsafe_allow_html=True)
                 except Exception as e:
                     logging.error(f"Lỗi hỏi AI: {e}")
                     st.error(f"Lỗi khi hỏi AI: {e}")


### PR DESCRIPTION
## Summary
- allow basic HTML rendering in chat tab output so answers format correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a308762988324a4293a5f5f8070a8