### PR TITLE
Improve results table scroll

### DIFF
--- a/src/main_engine/tabs/results_tab.py
+++ b/src/main_engine/tabs/results_tab.py
@@ -34,7 +34,7 @@ def render() -> None:
 
         table_html = df.to_html(escape=False, index=False)
         styled_html = (
-            "<div style='max-height: 500px; overflow-y: auto; overflow-x: auto;'>"
+            "<div class='results-table-container' style='max-height: 500px; overflow-y: auto;'>"
             f"{table_html}"
             "</div>"
         )

--- a/static/style.css
+++ b/static/style.css
@@ -101,3 +101,11 @@ table.dataframe th,
 table.dataframe td {
   padding: 4px 6px;
 }
+
+/* Enable horizontal scroll for results table */
+.results-table-container {
+  overflow-x: auto;
+}
+.results-table-container table.dataframe {
+  width: max-content;
+}


### PR DESCRIPTION
## Summary
- add horizontal scroll style for results table container
- update results tab markup to use the new style

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a3c89fed88324acba5b8fb31962b8