### PR TITLE
Add global loading overlay

### DIFF
--- a/src/main_engine/app.py
+++ b/src/main_engine/app.py
@@ -31,6 +31,7 @@ if __package__ is None:
     __package__ = "main_engine"
 
 import streamlit as st
+from modules.ui_utils import loading_overlay
 
 import requests
 import pandas as pd
@@ -503,8 +504,7 @@ def process_chat_message(user_input: str):
         })
         
         # Get AI response
-        with st.spinner("🤖 AI đang suy nghĩ..."):
-            # Import QA chatbot
+        with loading_overlay("🤖 AI đang suy nghĩ..."):
             try:
                 from modules.qa_chatbot import QAChatbot
                 
@@ -754,7 +754,7 @@ def render_sidebar():
             if not api_key:
                 st.sidebar.warning("⚠️ Vui lòng nhập API Key trước khi lấy models")
             else:
-                with st.spinner("Đang lấy danh sách models..."):
+                with loading_overlay("Đang lấy danh sách models..."):
                     models = get_available_models(provider, api_key)
                     if models:
                         safe_session_state_set("available_models", models)

--- a/src/main_engine/tabs/chat_tab.py
+++ b/src/main_engine/tabs/chat_tab.py
@@ -3,6 +3,7 @@ import os
 import pandas as pd
 import streamlit as st
 from typing import cast
+from modules.ui_utils import loading_overlay
 
 from modules.qa_chatbot import QAChatbot
 from modules.config import OUTPUT_CSV
@@ -34,7 +35,7 @@ def render(provider: str, model: str, api_key: str) -> None:
                 model=cast(str, model),
                 api_key=cast(str, api_key),
             )
-            with st.spinner("Đang hỏi AI..."):
+            with loading_overlay("Đang hỏi AI..."):
                 try:
                     logging.info("Đang gửi câu hỏi tới AI")
                     answer = chatbot.ask_question(question, df)

--- a/src/main_engine/tabs/single_tab.py
+++ b/src/main_engine/tabs/single_tab.py
@@ -5,6 +5,7 @@ import streamlit as st
 from modules.cv_processor import CVProcessor
 from modules.config import get_model_price
 from modules.dynamic_llm_client import DynamicLLMClient
+from modules.ui_utils import loading_overlay
 
 
 def render(provider: str, model: str, api_key: str, root: Path) -> None:
@@ -21,7 +22,7 @@ def render(provider: str, model: str, api_key: str, root: Path) -> None:
     if uploaded:
         tmp_file = root / f"tmp_{uploaded.name}"
         tmp_file.write_bytes(uploaded.getbuffer())
-        with st.spinner(f"Đang trích xuất & phân tích... (LLM: {provider}/{label})"):
+        with loading_overlay(f"Đang trích xuất & phân tích... (LLM: {provider}/{label})"):
             logging.info(f"Xử lý file đơn {uploaded.name}")
             proc = CVProcessor(
                 llm_client=DynamicLLMClient(

--- a/src/modules/ui_utils.py
+++ b/src/modules/ui_utils.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+from contextlib import contextmanager
+import streamlit as st
+
+
+@contextmanager
+def loading_overlay(message: str = "Đang xử lý..."):
+    """Hiển thị overlay loading toàn trang."""
+    placeholder = st.empty()
+    overlay_html = f"""
+    <div class='loading-overlay'>
+        <div class='loading-spinner'></div>
+        <div class='loading-text'>{message}</div>
+    </div>
+    """
+    placeholder.markdown(overlay_html, unsafe_allow_html=True)
+    try:
+        yield
+    finally:
+        placeholder.empty()
+
+__all__ = ["loading_overlay"]

--- a/static/style.css
+++ b/static/style.css
@@ -109,3 +109,37 @@ table.dataframe td {
 .results-table-container table.dataframe {
   width: max-content;
 }
+/* Loading overlay styles */
+.loading-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+}
+
+.loading-spinner {
+  border: 6px solid #f3f3f3;
+  border-top: 6px solid var(--btn-gold);
+  border-radius: 50%;
+  width: 60px;
+  height: 60px;
+  animation: spin 1s linear infinite;
+}
+
+.loading-text {
+  color: var(--btn-text-color);
+  margin-top: 10px;
+  font-weight: bold;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}


### PR DESCRIPTION
## Summary
- add UI utility for global loading overlay
- use loading overlay in Streamlit pages instead of default spinner
- append CSS styling for overlay

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a4338f9b483249467d96fb28acb14