### PR TITLE
Improve results table layout

### DIFF
--- a/src/main_engine/tabs/results_tab.py
+++ b/src/main_engine/tabs/results_tab.py
@@ -34,7 +34,7 @@ def render() -> None:
 
         table_html = df.to_html(escape=False, index=False)
         styled_html = (
-            "<div class='results-table-container' style='max-height: 500px; overflow-y: auto;'>"
+            "<div class='results-table-container' style='max-height: 500px; overflow-y: auto; width: 100%;'>"
             f"{table_html}"
             "</div>"
         )

--- a/static/style.css
+++ b/static/style.css
@@ -105,9 +105,11 @@ table.dataframe td {
 /* Enable horizontal scroll for results table */
 .results-table-container {
   overflow-x: auto;
+  max-width: 100%;
 }
 .results-table-container table.dataframe {
   width: max-content;
+  max-width: 100%;
 }
 /* Loading overlay styles */
 .loading-overlay {


### PR DESCRIPTION
## Summary
- keep results table from forcing horizontal scroll
- ensure width is constrained to the container

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a4814ff44832492e7d249ce3aab8c