### PR TITLE
Fix Streamlit tab styling selectors

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -63,13 +63,13 @@ button[data-baseweb="base-button"]:hover {
 }
 
 /* DataFrame styling */
-.css-1ex1afd {
+div[data-testid="stDataFrame"] {
   background-color: var(--cv-bg-color) !important;
   color: var(--cv-text-color) !important;
 }
 
 /* Tabs styling */
-.css-1v0mbdj .css-1xt0zh0 {
+.stTabs [data-baseweb="tabs"] {
   background-color: var(--cv-bg-color) !important;
   color: var(--cv-text-color) !important;
 }


### PR DESCRIPTION
## Summary
- replace autogenerated selectors with stable Streamlit attributes in `static/style.css`

## Testing
- `pytest -q`
- `streamlit run src/main_engine/main.py` *(started server to check tabs)*

------
https://chatgpt.com/codex/tasks/task_e_685a4b5a0b488324a0b71e052cd79e4f