### PR TITLE
Improve Windows setup reliability

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -107,6 +107,14 @@ tạo các thư mục cần thiết.
 2. Giải nén (nếu tải ZIP) và mở `cmd` trong thư mục dự án.
 3. Chạy `setup.cmd` để tự động tạo `.env`, tạo virtual env và cài đặt
    dependencies.
+   Nếu thư mục dự án nằm trong OneDrive/Dropbox và cài đặt bị lỗi liên quan đến
+   `hardlink` hoặc `Failed to read typing-extensions`, hãy chạy thêm:
+
+   ```cmd
+   set UV_LINK_MODE=copy
+   ```
+
+   rồi xóa thư mục `.venv` (nếu đã có) và chạy lại `setup.cmd`.
 4. Mở file `.env` vừa tạo và điền các biến như `GOOGLE_API_KEY`, thông tin
    `EMAIL_*`.
 5. Cuối cùng chạy `run_resume_ai.cmd` để mở ngay giao diện Streamlit.

--- a/setup_window.cmd
+++ b/setup_window.cmd
@@ -66,12 +66,14 @@ if not exist "%~dp0.venv\Scripts\activate.bat" (
 :: 4) Kích hoạt virtual environment
 call "%~dp0.venv\Scripts\activate.bat"
 echo Đã kích hoạt virtual environment.
+:: Đặt chế độ copy để tránh lỗi hardlink khi thư mục nằm trên dịch vụ cloud
+set UV_LINK_MODE=copy
 
 :: 5) Cài đặt dependencies
 echo Đang cài đặt dependencies...
 %PYTHON_CMD% -m pip install --upgrade uv
 uv pip install --upgrade pip
-uv pip install -r "%~dp0requirements.txt"
+uv pip install -r "%~dp0requirements.txt" --link-mode=copy --reinstall
 echo Hoàn tất cài đặt dependencies.
 
 :: 6) Tạo thư mục attachments


### PR DESCRIPTION
## Summary
- set `UV_LINK_MODE=copy` automatically when running Windows setup
- reinstall packages with `--link-mode=copy` to avoid hardlink issues
- document troubleshooting step for Windows setup failures

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b96858448832495da35bb0f02cef2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Enhanced Windows quick setup instructions in the README with troubleshooting steps for installation errors related to cloud-synced directories.

- **Bug Fixes**
  - Improved Windows setup script to prevent installation failures on cloud storage folders by adjusting environment variables and installation options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->