### PR TITLE
Improve results table UI

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -110,6 +110,24 @@ table.dataframe td {
 .results-table-container table.dataframe {
   width: max-content;
   max-width: 100%;
+  border-collapse: collapse;
+}
+
+/* Sticky header and zebra rows */
+.results-table-container th {
+  position: sticky;
+  top: 0;
+  background-color: var(--btn-gold);
+  color: var(--btn-text-color);
+  z-index: 1;
+}
+
+.results-table-container tbody tr:nth-child(even) {
+  background-color: rgba(0, 0, 0, 0.04);
+}
+
+.results-table-container tbody tr:hover {
+  background-color: rgba(0, 0, 0, 0.08);
 }
 /* Loading overlay styles */
 .loading-overlay {


### PR DESCRIPTION
## Summary
- enhance results table styling with sticky header and hover states

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cc1c33f0c8324bd190c9e00391753