### PR TITLE
Fix results table layout

### DIFF
--- a/src/main_engine/tabs/results_tab.py
+++ b/src/main_engine/tabs/results_tab.py
@@ -34,7 +34,7 @@ def render() -> None:
 
         table_html = df.to_html(escape=False, index=False)
         styled_html = (
-            "<div class='results-table-container' style='max-height: 500px; overflow-y: auto; width: 100%;'>"
+            "<div class='results-table-container' style='max-height: 60vh; overflow: auto; width: 100%;'>"
             f"{table_html}"
             "</div>"
         )

--- a/static/style.css
+++ b/static/style.css
@@ -112,6 +112,12 @@ table.dataframe td {
   max-width: 100%;
   border-collapse: collapse;
 }
+/* Wrap text inside the results table to avoid stretching the layout */
+.results-table-container td {
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-width: 300px;
+}
 
 /* Sticky header and zebra rows */
 .results-table-container th {


### PR DESCRIPTION
## Summary
- wrap text in result table cells so long entries don't stretch the page
- allow the results table to scroll both horizontally and vertically

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_685cc47932288324a65f21090c3c24a4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved results table container to use relative height and allow both vertical and horizontal scrolling for better responsiveness.
  * Enhanced table cell formatting to wrap long text and limit cell width, preventing layout stretching and improving readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->