### PR TITLE
Improve email fetcher timestamps

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -45,9 +45,11 @@ HoanCau AI Resume Processor là hệ thống tự động trích xuất thông t
   ```
 - Chạy lệnh thử tay:
   ```bash
-  python3 -c "from modules.email_fetcher import EmailFetcher; f=EmailFetcher(); f.connect(); print(f.fetch_cv_attachments())"
+  python3 -c "from modules.email_fetcher import EmailFetcher; f=EmailFetcher(); f.connect(); print(f.fetch_cv_attachments()); print(f.last_fetch_info)"
   ```
   Kết quả trả về danh sách đường dẫn file (nếu trống, nghĩa là không tìm thấy attachment trong inbox).
+  Thuộc tính `last_fetch_info` chứa cặp `(path, sent_time)` cho mỗi file mới tải.
+  Khi xử lý bằng `CVProcessor`, cột `Thời gian gửi` trong bảng kết quả sẽ hiển thị giá trị `sent_time` này.
 - Nếu vẫn không có email, kiểm tra folder IMAP mặc định là `INBOX`, hoặc đổi:
   ```python
   f.mail.select('INBOX.Sent Mail')  # hoặc tên folder khác

--- a/src/modules/cv_processor.py
+++ b/src/modules/cv_processor.py
@@ -200,6 +200,9 @@ class CVProcessor:
         """
         # fetch từ email nếu có fetcher
         files: List[str] = self.fetcher.fetch_cv_attachments() if self.fetcher else []
+        sent_map = {}
+        if self.fetcher:
+            sent_map = dict(getattr(self.fetcher, "last_fetch_info", []))
         if not files:
             logger.info("🔍 Không tìm thấy qua fetcher, dò thư mục attachments...")
             files = [
@@ -218,6 +221,7 @@ class CVProcessor:
             # gom thông tin vào dict
             rows.append({
                 "Nguồn": os.path.basename(path),
+                "Thời gian gửi": sent_map.get(path, ""),
                 "Họ tên": info.get("ten", ""),
                 "Tuổi": info.get("tuoi", ""),
                 "Email": info.get("email", ""),
@@ -230,6 +234,7 @@ class CVProcessor:
 
         df = pd.DataFrame(rows, columns=[
             "Nguồn",
+            "Thời gian gửi",
             "Họ tên",
             "Tuổi",
             "Email",

--- a/test/test_email_fetcher.py
+++ b/test/test_email_fetcher.py
@@ -35,6 +35,7 @@ def test_fetch_cv_attachments(email_fetcher_module, tmp_path):
 
     msg = EmailMessage()
     msg['Subject'] = 'CV Nguyen'
+    msg['Date'] = 'Wed, 20 Sep 2023 10:15:00 -0400'
     msg.set_content('body')
     msg.add_attachment(b'data', maintype='application', subtype='pdf', filename='cv.pdf')
     raw = msg.as_bytes()
@@ -55,3 +56,5 @@ def test_fetch_cv_attachments(email_fetcher_module, tmp_path):
     expected = tmp_path / 'cv.pdf'
     assert files == [str(expected)]
     assert expected.exists()
+    assert fetcher.last_fetch_info == [(str(expected), '2023-09-20T10:15:00-04:00')]
+


### PR DESCRIPTION
## Summary
- capture and expose attachment sent times via `last_fetch_info`
- include email sent time in `CVProcessor` results
- test coverage for timestamp extraction
- document new timestamp metadata

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cc20a7bc083248f3a4e687feb126d