### PR TITLE
Move sent time column before source

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,7 @@ HoanCau AI Resume Processor là hệ thống tự động trích xuất thông t
   ```
   Kết quả trả về danh sách đường dẫn file (nếu trống, nghĩa là không tìm thấy attachment trong inbox).
   Thuộc tính `last_fetch_info` chứa cặp `(path, sent_time)` cho mỗi file mới tải.
-  Khi xử lý bằng `CVProcessor`, cột `Thời gian gửi` trong bảng kết quả sẽ hiển thị giá trị `sent_time` này.
+  Khi xử lý bằng `CVProcessor`, cột `Thời gian gửi` (đứng trước cột `Nguồn`) trong bảng kết quả sẽ hiển thị giá trị `sent_time` này.
 - Nếu vẫn không có email, kiểm tra folder IMAP mặc định là `INBOX`, hoặc đổi:
   ```python
   f.mail.select('INBOX.Sent Mail')  # hoặc tên folder khác

--- a/src/modules/cv_processor.py
+++ b/src/modules/cv_processor.py
@@ -220,8 +220,8 @@ class CVProcessor:
             info = self.extract_info_with_llm(txt) or {}
             # gom thông tin vào dict
             rows.append({
-                "Nguồn": os.path.basename(path),
                 "Thời gian gửi": sent_map.get(path, ""),
+                "Nguồn": os.path.basename(path),
                 "Họ tên": info.get("ten", ""),
                 "Tuổi": info.get("tuoi", ""),
                 "Email": info.get("email", ""),
@@ -233,8 +233,8 @@ class CVProcessor:
             })
 
         df = pd.DataFrame(rows, columns=[
-            "Nguồn",
             "Thời gian gửi",
+            "Nguồn",
             "Họ tên",
             "Tuổi",
             "Email",


### PR DESCRIPTION
## Summary
- reorder fields in `CVProcessor` so the `Thời gian gửi` column precedes `Nguồn`
- clarify README with the new column position

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cc75a04908324aa6c4923617bf1aa