### PR TITLE
Fix results table width

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -109,7 +109,6 @@ table.dataframe td {
 }
 .results-table-container table.dataframe {
   width: max-content;
-  max-width: 100%;
   border-collapse: collapse;
 }
 /* Wrap text inside the results table to avoid stretching the layout */


### PR DESCRIPTION
## Summary
- allow the results table to expand naturally so wide tables scroll horizontally

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cc9a73e5c83249b4b0445d8669c93