### PR TITLE
Fix missing sent time column in attachment processing

### DIFF
--- a/src/main_engine/tabs/process_tab.py
+++ b/src/main_engine/tabs/process_tab.py
@@ -49,6 +49,7 @@ def render(provider: str, model: str, api_key: str) -> None:
                 info = processor.extract_info_with_llm(text)
                 results.append(
                     {
+                        "Thời gian gửi": "",
                         "Nguồn": fname,
                         "Họ tên": info.get("ten", ""),
                         "Tuổi": info.get("tuoi", ""),
@@ -64,6 +65,7 @@ def render(provider: str, model: str, api_key: str) -> None:
             df = pd.DataFrame(
                 results,
                 columns=[
+                    "Thời gian gửi",
                     "Nguồn",
                     "Họ tên",
                     "Tuổi",


### PR DESCRIPTION
## Summary
- include `Thời gian gửi` column when running batch processing from attachments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cc9d70204832494bf3a612803bf89