### PR TITLE
Fix results tab table layout

### DIFF
--- a/src/main_engine/tabs/results_tab.py
+++ b/src/main_engine/tabs/results_tab.py
@@ -34,7 +34,7 @@ def render() -> None:
 
         table_html = df.to_html(escape=False, index=False)
         styled_html = (
-            "<div class='results-table-container' style='max-height: 60vh; overflow: auto; width: 100%;'>"
+            "<div class='results-table-container' style='max-height: 60vh; overflow: auto;'>"
             f"{table_html}"
             "</div>"
         )

--- a/static/style.css
+++ b/static/style.css
@@ -108,7 +108,8 @@ table.dataframe td {
   max-width: 100%;
 }
 .results-table-container table.dataframe {
-  width: max-content;
+  width: 100%;
+  table-layout: auto;
   border-collapse: collapse;
 }
 /* Wrap text inside the results table to avoid stretching the layout */


### PR DESCRIPTION
## Summary
- prevent results table from stretching layout
- remove inline width from table container

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ccc925a808324b7a6370e45724c6b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the results table layout to occupy the full container width with improved automatic column sizing.
  * Adjusted the container styling for the results table to enhance display consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->