### PR TITLE
Fix NaN timestamps

### DIFF
--- a/src/modules/cv_processor.py
+++ b/src/modules/cv_processor.py
@@ -219,8 +219,10 @@ class CVProcessor:
             txt = self.extract_text(path)  # đọc text file
             info = self.extract_info_with_llm(txt) or {}
             # gom thông tin vào dict
+            sent_time = sent_map.get(path, "")
+            sent_time = sent_time if sent_time is not None else ""
             rows.append({
-                "Thời gian gửi": sent_map.get(path, ""),
+                "Thời gian gửi": sent_time,
                 "Nguồn": os.path.basename(path),
                 "Họ tên": info.get("ten", ""),
                 "Tuổi": info.get("tuoi", ""),

--- a/src/modules/email_fetcher.py
+++ b/src/modules/email_fetcher.py
@@ -142,14 +142,14 @@ class EmailFetcher:
                 msg = email.message_from_bytes(msg_data[0][1])
 
                 # Get sent time from Date header
-                sent_time: str | None = None
+                sent_time: str | None = ""
                 date_hdr = msg.get('Date')
                 if date_hdr:
                     try:
                         dt = parsedate_to_datetime(date_hdr)
                         sent_time = dt.isoformat()
                     except Exception:
-                        sent_time = None
+                        sent_time = ""
 
                 # Lấy tiêu đề và nội dung để lọc theo keywords
                 try:


### PR DESCRIPTION
## Summary
- ensure missing email dates return empty string
- guard against `None` when populating `sent_time` in CV processing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cdaaefe14832492a6f017702cda5c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing or invalid sent time values by consistently displaying an empty string instead of "None" when the sent time cannot be determined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->