### PR TITLE
Set gemini-2.5 flash preview as default model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,8 +13,8 @@
 LLM_PROVIDER=google
 
 # Model AI sử dụng (bắt buộc)
-# Ví dụ: gemini-2.0-flash, gpt-4o, claude-3-sonnet
-LLM_MODEL=gemini-2.0-flash
+# Ví dụ: gemini-2.5-flash-lite-preview-06-17, gpt-4o, claude-3-sonnet
+LLM_MODEL=gemini-2.5-flash-lite-preview-06-17
 
 # Cấu hình nâng cao cho AI
 AI_TEMPERATURE=0.3              # Độ sáng tạo (0.0-1.0)

--- a/src/main_engine/app.py
+++ b/src/main_engine/app.py
@@ -316,7 +316,7 @@ def get_available_models(provider: str, api_key: str) -> list:
         logger.error(f"Failed to get models for {provider}: {e}")
     
     # Fallback to default model
-    default_model = LLM_CONFIG.get("model", "gemini-2.0-flash")
+    default_model = LLM_CONFIG.get("model", "gemini-2.5-flash-lite-preview-06-17")
     return [default_model]
 
 initialize_session_state()

--- a/src/main_engine/chat.py
+++ b/src/main_engine/chat.py
@@ -145,7 +145,7 @@ def process_chat_message(user_input: str):
         with loading_overlay("🤖 AI đang suy nghĩ..."):
             from modules.qa_chatbot import QAChatbot
             provider = st.session_state.get("selected_provider", "google")
-            model = st.session_state.get("selected_model", "gemini-2.0-flash")
+            model = st.session_state.get("selected_model", "gemini-2.5-flash-lite-preview-06-17")
             api_key = st.session_state.get(f"{provider}_api_key", "")
             if not api_key:
                 st.error("❌ API Key chưa được cấu hình!")

--- a/src/main_engine/sidebar.py
+++ b/src/main_engine/sidebar.py
@@ -97,9 +97,9 @@ def render_sidebar(validate_configuration, detect_platform, get_available_models
     models = safe_session_state_get("available_models", get_available_models(provider, api_key))
     if not models:
         st.sidebar.error("❌ Không lấy được models, vui lòng kiểm tra API Key.")
-        models = [LLM_CONFIG.get("model", "gemini-2.0-flash")]
+        models = [LLM_CONFIG.get("model", "gemini-2.5-flash-lite-preview-06-17")]
 
-    default_model = LLM_CONFIG.get("model", "gemini-2.0-flash")
+    default_model = LLM_CONFIG.get("model", "gemini-2.5-flash-lite-preview-06-17")
     if default_model not in models and models:
         default_model = models[0]
     if not safe_session_state_get("selected_model") or safe_session_state_get("selected_model") not in models:

--- a/src/modules/config.py
+++ b/src/modules/config.py
@@ -32,7 +32,7 @@ def _get_env(varname: str, default: str = "") -> str:
 
 # --- Nhà cung cấp (provider) và model mặc định ---
 LLM_PROVIDER = _get_env("LLM_PROVIDER", "google").lower()
-LLM_MODEL = _get_env("LLM_MODEL", "gemini-2.0-flash")
+LLM_MODEL = _get_env("LLM_MODEL", "gemini-2.5-flash-lite-preview-06-17")
 
 # --- Khóa API cho Google, OpenRouter và các platform khác (không bắt buộc) ---
 GOOGLE_API_KEY = _get_env("GOOGLE_API_KEY")
@@ -109,7 +109,7 @@ GOOGLE_FALLBACK_MODELS: List[str] = [
     "gemini-1.5-pro", "gemini-1.5-pro-latest", "gemini-pro", "gemini-pro-vision",
     # Newer and experimental variants
     "gemini-2.0-alpha", "gemini-2.0-vision", "gemini-2.0-vision-extended",
-    "gemini-2.0-flash",
+    "gemini-2.0-flash", "gemini-2.5-flash-lite-preview-06-17",
     "gemini-2.5-pro", "gemini-2.5-pro-latest"
 ]
 OPENROUTER_FALLBACK_MODELS: List[str] = [
@@ -127,6 +127,7 @@ MODEL_PRICES: Dict[str, str] = {
     "gemini-pro": "1$/token",
     "gemini-pro-vision": "1$/token",
     "gemini-2.0-flash": "unknown",
+    "gemini-2.5-flash-lite-preview-06-17": "unknown",
     # OpenRouter fallback models (giá tham khảo, có thể thay đổi)
     "anthropic/claude-3.5-sonnet": "variable",
     "anthropic/claude-3-haiku": "variable",


### PR DESCRIPTION
## Summary
- update default LLM model to `gemini-2.5-flash-lite-preview-06-17`
- update example environment file
- include new model in fallback and price lists
- adjust app, chat and sidebar defaults

## Testing
- `pip install -q -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cda767cfc8324b8b2a8f7bdfb90b1