### PR TITLE
Fix NaN display in results table

### DIFF
--- a/src/main_engine/tabs/results_tab.py
+++ b/src/main_engine/tabs/results_tab.py
@@ -10,7 +10,8 @@ def render() -> None:
     """Render UI for viewing and downloading results."""
     st.subheader("Xem và tải kết quả")
     if os.path.exists(OUTPUT_CSV):
-        df = pd.read_csv(OUTPUT_CSV, encoding="utf-8-sig")
+        df = pd.read_csv(OUTPUT_CSV, encoding="utf-8-sig", keep_default_na=False)
+        df.fillna("", inplace=True)
 
         def make_link(fname: str) -> str:
             """Create a safe link that works across browsers."""


### PR DESCRIPTION
## Summary
- keep blank strings when loading CSV results
- replace missing values with empty string

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cdf6065648324895fa08d7db1af49