### PR TITLE
Improve result table UI

### DIFF
--- a/src/main_engine/tabs/results_tab.py
+++ b/src/main_engine/tabs/results_tab.py
@@ -32,6 +32,13 @@ def render() -> None:
         if "Nguồn" in df.columns:
             df["Nguồn"] = df["Nguồn"].apply(make_link)
 
+        # Wrap long text fields with a scrollable container
+        for col in ["Học vấn", "Kinh nghiệm", "Kỹ năng"]:
+            if col in df.columns:
+                df[col] = df[col].apply(
+                    lambda v: f"<div class='cell-scroll'>{v}</div>" if pd.notna(v) else ""
+                )
+
         table_html = df.to_html(escape=False, index=False)
         styled_html = (
             "<div class='results-table-container' style='max-height: 60vh; overflow: auto;'>"

--- a/static/style.css
+++ b/static/style.css
@@ -119,6 +119,13 @@ table.dataframe td {
   max-width: 300px;
 }
 
+/* Scrollable cell for long text */
+.results-table-container .cell-scroll {
+  max-height: 6em;
+  overflow-y: auto;
+  display: block;
+}
+
 /* Sticky header and zebra rows */
 .results-table-container th {
   position: sticky;


### PR DESCRIPTION
## Summary
- wrap long fields in results table with a scrollable container
- add CSS to limit cell height

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cdfc1e9ac8324b2e49509ea9dfb61