### PR TITLE
Add unseen_only param for CV processing

### DIFF
--- a/scripts/cli_agent.py
+++ b/scripts/cli_agent.py
@@ -43,13 +43,11 @@ def watch(interval, host, port, user, password, unseen_only):
 def full_process(unseen_only):
     """Chạy đầy đủ quy trình fetch và xử lý CV"""
     click.echo("Bắt đầu full process...")
-    # Fetch email
+    # Fetch email & process CVs
     fetcher = EmailFetcher(settings.email_host, settings.email_port, settings.email_user, settings.email_pass)
     fetcher.connect()
-    fetcher.fetch_cv_attachments(unseen_only=unseen_only)
-    # Process CVs
     processor = CVProcessor(fetcher, llm_client=LLMClient())
-    df = processor.process()
+    df = processor.process(unseen_only=unseen_only)
     if df.empty:
         click.echo("Không có CV mới để xử lý.")
     else:

--- a/test/test_cli_agent.py
+++ b/test/test_cli_agent.py
@@ -43,7 +43,8 @@ def cli_module(monkeypatch, tmp_path):
     class DummyProcessor:
         def __init__(self, *a, **k):
             pass
-        def process(self):
+        def process(self, unseen_only=True):
+            calls['process_unseen'] = unseen_only
             return DummyDF(calls.get('df_rows', []))
         def save_to_csv(self, df, path):
             calls['saved'] = path


### PR DESCRIPTION
## Summary
- allow specifying unseen flag in `CVProcessor.process`
- update CLI to pass unseen flag to processor
- adapt CLI tests for new parameter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ce28305048324ba7784c5ce293880