### PR TITLE
Fix email timestamp display

### DIFF
--- a/src/main_engine/app.py
+++ b/src/main_engine/app.py
@@ -535,7 +535,14 @@ with tab_fetch:
     fetch_tab.render(email_user, email_pass, unseen_only)
 
 with tab_process:
-    process_tab.render(provider, model, api_key)
+    process_tab.render(
+        provider,
+        model,
+        api_key,
+        email_user=email_user,
+        email_pass=email_pass,
+        unseen_only=unseen_only,
+    )
 
 with tab_single:
     single_tab.render(provider, model, api_key, ROOT)

--- a/src/main_engine/tabs/process_tab.py
+++ b/src/main_engine/tabs/process_tab.py
@@ -1,87 +1,61 @@
 import logging
-import os
-import pandas as pd
 import streamlit as st
 
 from modules.cv_processor import CVProcessor
-from modules.config import ATTACHMENT_DIR, OUTPUT_CSV, OUTPUT_EXCEL, get_model_price
+from modules.email_fetcher import EmailFetcher
+from modules.config import (
+    OUTPUT_CSV,
+    OUTPUT_EXCEL,
+    EMAIL_HOST,
+    EMAIL_PORT,
+    get_model_price,
+)
 from modules.dynamic_llm_client import DynamicLLMClient
 
 
-def render(provider: str, model: str, api_key: str) -> None:
-    """Render UI for processing CV files in attachments."""
-    st.subheader("Xử lý CV từ attachments")
+def render(
+    provider: str,
+    model: str,
+    api_key: str,
+    email_user: str = "",
+    email_pass: str = "",
+    unseen_only: bool = True,
+) -> None:
+    """Render UI for processing CV files from attachments or email."""
+    st.subheader("Xử lý CV từ attachments hoặc email")
     price = get_model_price(model)
     label = f"{model} ({price})" if price != "unknown" else model
     st.markdown(f"**LLM:** `{provider}` / `{label}`")
 
-    # Placeholders to avoid creating new widgets on every run
-    progress_slot = st.empty()
-    status_slot = st.empty()
+    if st.button(
+        "Bắt đầu xử lý CV",
+        help="Phân tích CV trong attachments hoặc fetch từ email nếu có thông tin",
+    ):
+        logging.info("Bắt đầu xử lý batch CV")
+        fetcher = None
+        if email_user and email_pass:
+            try:
+                fetcher = EmailFetcher(EMAIL_HOST, EMAIL_PORT, email_user, email_pass)
+                fetcher.connect()
+            except Exception as e:
+                st.error(f"Không thể kết nối email: {e}")
+                logging.error("Email connection failed: %s", e)
+                fetcher = None
 
-    if st.button("Bắt đầu xử lý CV", help="Phân tích tất cả file trong attachments"):
-        logging.info("Bắt đầu xử lý batch CV từ attachments")
-        files = [
-            str(p)
-            for p in ATTACHMENT_DIR.glob("*")
-            if p.suffix.lower() in (".pdf", ".docx")
-        ]
-        if not files:
-            st.warning("Không có file CV trong thư mục attachments để xử lý.")
+        processor = CVProcessor(
+            fetcher,
+            llm_client=DynamicLLMClient(provider=provider, model=model, api_key=api_key),
+        )
+
+        with st.spinner("Đang xử lý CV..."):
+            df = processor.process(unseen_only=unseen_only)
+
+        if df.empty:
+            st.info("Không có CV nào để xử lý.")
         else:
-            processor = CVProcessor(
-                llm_client=DynamicLLMClient(
-                    provider=provider,
-                    model=model,
-                    api_key=api_key,
-                )
-            )
-            # Reuse placeholders so old progress bars don't stack
-            progress = progress_slot.progress(0)
-            status = status_slot.empty()
-            results = []
-            total = len(files)
-            for idx, path in enumerate(files, start=1):
-                fname = os.path.basename(path)
-                status.text(f"({idx}/{total}) Đang xử lý: {fname}")
-                logging.info(f"Đang xử lý {fname}")
-                text = processor.extract_text(path)
-                info = processor.extract_info_with_llm(text)
-                results.append(
-                    {
-                        "Thời gian gửi": "",
-                        "Nguồn": fname,
-                        "Họ tên": info.get("ten", ""),
-                        "Tuổi": info.get("tuoi", ""),
-                        "Email": info.get("email", ""),
-                        "Điện thoại": info.get("dien_thoai", ""),
-                        "Địa chỉ": info.get("dia_chi", ""),
-                        "Học vấn": info.get("hoc_van", ""),
-                        "Kinh nghiệm": info.get("kinh_nghiem", ""),
-                        "Kỹ năng": info.get("ky_nang", ""),
-                    }
-                )
-                progress.progress(idx / total)
-            df = pd.DataFrame(
-                results,
-                columns=[
-                    "Thời gian gửi",
-                    "Nguồn",
-                    "Họ tên",
-                    "Tuổi",
-                    "Email",
-                    "Điện thoại",
-                    "Địa chỉ",
-                    "Học vấn",
-                    "Kinh nghiệm",
-                    "Kỹ năng",
-                ],
-            )
             processor.save_to_csv(df, str(OUTPUT_CSV))
             processor.save_to_excel(df, str(OUTPUT_EXCEL))
-            logging.info(f"Đã xử lý {len(df)} CV và lưu kết quả")
+            logging.info("Đã xử lý %s CV và lưu kết quả", len(df))
             st.success(
                 f"Đã xử lý {len(df)} CV và lưu vào `{OUTPUT_CSV.name}` và `{OUTPUT_EXCEL.name}`."
             )
-            progress_slot.empty()
-            status_slot.empty()


### PR DESCRIPTION
## Summary
- support processing CVs directly from email with timestamps
- render email credentials into `process_tab.render`
- read CSV results without converting empty cells to NaN

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cea07a5148324865b0afa79cc3945

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to process CVs directly from email accounts by providing email credentials and an option to process only unseen emails.
  * Updated the user interface to reflect support for email-based CV processing, including new help texts and feedback messages.

* **Refactor**
  * Streamlined the CV processing workflow for improved reliability and user experience, with simplified logging and clearer status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->