### PR TITLE
Improve sent time display

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -50,6 +50,7 @@ HoanCau AI Resume Processor là hệ thống tự động trích xuất thông t
   Kết quả trả về danh sách đường dẫn file (nếu trống, nghĩa là không tìm thấy attachment trong inbox).
   Thuộc tính `last_fetch_info` chứa cặp `(path, sent_time)` cho mỗi file mới tải.
   Khi xử lý bằng `CVProcessor`, cột `Thời gian nhận` (đứng trước cột `Nguồn`) trong bảng kết quả sẽ hiển thị giá trị `sent_time` này.
+  Chuỗi ISO sẽ được định dạng lại cho dễ đọc, ví dụ `2:33 pm 26/6/2025`.
   Các giá trị thời gian này được lưu lại trong file `attachments/sent_times.json` để lần xử lý sau vẫn giữ nguyên thông tin.
 - Nếu vẫn không có email, kiểm tra folder IMAP mặc định là `INBOX`, hoặc đổi:
   ```python

--- a/test/test_cv_processor.py
+++ b/test/test_cv_processor.py
@@ -98,7 +98,8 @@ def test_process_includes_sent_time(cv_processor_class, tmp_path, monkeypatch):
         value = df['Thời gian nhận'].iloc[0]
     else:
         value = df[0]['Thời gian nhận']
-    assert value == '2023-09-20T10:15:00Z'
+    expected = cp_module.format_sent_time_display('2023-09-20T10:15:00Z')
+    assert value == expected
 
 
 def test_process_uses_saved_sent_time(cv_processor_class, tmp_path, monkeypatch):
@@ -123,4 +124,5 @@ def test_process_uses_saved_sent_time(cv_processor_class, tmp_path, monkeypatch)
         value = df['Thời gian nhận'].iloc[0]
     else:
         value = df[0]['Thời gian nhận']
-    assert value == '2023-09-20T12:00:00Z'
+    expected = cp_module.format_sent_time_display('2023-09-20T12:00:00Z')
+    assert value == expected


### PR DESCRIPTION
## Summary
- add `format_sent_time_display` helper
- format `Thời gian nhận` column using this helper
- update tests to expect the formatted string
- document new behaviour in README

## Testing
- `python3 -m pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cf7f33164832482e17f43ce96fb6d