### PR TITLE
Fix path handling in Windows scripts

### DIFF
--- a/setup_window.cmd
+++ b/setup_window.cmd
@@ -1,5 +1,6 @@
 @echo off
 setlocal enableextensions enabledelayedexpansion
+pushd %~dp0
 
 cls
 echo ======================================================
@@ -28,6 +29,7 @@ if errorlevel 1 (
         echo Không tìm thấy winget để cài đặt Python tự động.
         echo Vui lòng cài đặt Python thủ công tại https://www.python.org.
         pause
+        popd
         exit /b 1
     )
     winget install --id Python.Python.3.11 --silent --accept-package-agreements --accept-source-agreements
@@ -35,6 +37,7 @@ if errorlevel 1 (
         echo Lỗi cài đặt Python bằng winget.
         echo Vui lòng cài đặt Python thủ công tại https://www.python.org rồi chạy lại script.
         pause
+        popd
         exit /b 1
     )
     echo Hoàn tất cài đặt Python.
@@ -83,4 +86,5 @@ if not exist "%~dp0attachments" (
 )
 
 echo Setup hoàn tất! Nhấn bất kỳ phím nào để thoát.
+popd
 pause

--- a/start_window.cmd
+++ b/start_window.cmd
@@ -1,5 +1,6 @@
 @echo off
 setlocal enableextensions enabledelayedexpansion
+pushd %~dp0
 
 cls
 echo ======================================================
@@ -22,6 +23,7 @@ python --version >nul 2>&1
 if errorlevel 1 (
     echo [ERROR] Python không được cài đặt hoặc không tìm thấy trong PATH.
     pause
+    popd
     exit /b 1
 )
 echo [OK] Đã có Python.
@@ -52,4 +54,5 @@ echo [MODE] Khởi động Streamlit UI...
 streamlit run "%~dp0src\main_engine\app.py"
 
 :end
+popd
 pause


### PR DESCRIPTION
## Summary
- ensure Windows batch files use `pushd` and `popd` so that paths resolve relative to script location

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d0bfeb3788324bd017516117dd65e