### PR TITLE
Add optional dev dependency flag to setup scripts

### DIFF
--- a/setup_linux.sh
+++ b/setup_linux.sh
@@ -2,6 +2,17 @@
 # HoanCau AI - Setup Script for macOS/Linux
 set -e
 
+# Usage: ./setup_linux.sh [--dev]
+#   --dev  Install requirements-dev.txt after requirements.txt
+
+# Parse arguments
+DEV_MODE=0
+for arg in "$@"; do
+    if [ "$arg" = "--dev" ]; then
+        DEV_MODE=1
+    fi
+done
+
 echo "=============================="
 echo " HoanCau AI - Setup Script "
 echo "=============================="
@@ -28,6 +39,13 @@ if ! command -v uv >/dev/null 2>&1; then
 fi
 uv pip install --upgrade pip
 uv pip install -r requirements.txt
+if [ $DEV_MODE -eq 1 ]; then
+    if [ -f "requirements-dev.txt" ]; then
+        uv pip install -r requirements-dev.txt
+    else
+        echo "Warning: requirements-dev.txt not found, skipping dev dependencies." >&2
+    fi
+fi
 
 # 5) Copy .env.example to .env if needed
 if [ ! -f ".env" ]; then

--- a/setup_window.cmd
+++ b/setup_window.cmd
@@ -7,16 +7,23 @@ echo                 RESUME AI - SETUP SCRIPT
 echo ======================================================
 :: ======================================================
 :: Resume AI - Setup Script
+:: Usage: setup_window.cmd [--dev]
+::   --dev  Cài thêm requirements-dev.txt sau khi cài requirements.txt
 :: Mục đích: Tự động thiết lập môi trường dự án
 ::   1) Kiểm tra Python và virtual env
 ::   2) Copy .env từ .env.example nếu chưa có
 ::   3) Tạo và kích hoạt venv
-::   4) Cài đặt dependencies
+::   4) Cài đặt dependencies (thêm --dev để cài requirements-dev.txt)
 ::   5) Tạo thư mục attachments
 :: ======================================================
 
 :: 0) Chuyển console sang UTF-8
 chcp 65001 >nul
+
+set DEV_MODE=0
+for %%i in (%*) do (
+    if /I "%%i"=="--dev" set DEV_MODE=1
+)
 
 :: 1) Kiểm tra Python
 set "PYTHON_CMD=python"
@@ -72,6 +79,13 @@ echo Đang cài đặt dependencies...
 %PYTHON_CMD% -m pip install --upgrade uv
 uv pip install --upgrade pip
 uv pip install -r "%~dp0requirements.txt"
+if %DEV_MODE%==1 (
+    if exist "%~dp0requirements-dev.txt" (
+        uv pip install -r "%~dp0requirements-dev.txt"
+    ) else (
+        echo Không tìm thấy requirements-dev.txt, bỏ qua cài đặt gói phát triển.
+    )
+)
 echo Hoàn tất cài đặt dependencies.
 
 :: 6) Tạo thư mục attachments


### PR DESCRIPTION
## Summary
- allow `--dev` flag in `setup_linux.sh` and `setup_window.cmd`
- document the flag in script comments
- install `requirements-dev.txt` when `--dev` is used

## Testing
- `bash setup_linux.sh --dev`
- `pytest -q` *(fails: AssertionError in `test_dynamic_llm_client.py::test_openrouter_missing_key`, `test_models.py::test_google_models`)*

------
https://chatgpt.com/codex/tasks/task_e_685d0c03cf2483249b2a5ff6faab71e6