### PR TITLE
Fix encoding bug in setup_window.cmd

### DIFF
--- a/setup_window.cmd
+++ b/setup_window.cmd
@@ -185,10 +185,9 @@ powershell -NoProfile -ExecutionPolicy Bypass -Command ^
     "    exit 1;" ^
     "}"
 
-REM Khôi phục encoding sau khi chạy PowerShell
-chcp %ORIG_CP% >nul
+set "PS_EXITCODE=%ERRORLEVEL%"
 
-if errorlevel 1 (
+if %PS_EXITCODE% NEQ 0 (
     echo [Lỗi] Không thể tạo shortcut bằng PowerShell.
     echo Đang thử tạo file batch thay thế...
     


### PR DESCRIPTION
## Summary
- keep UTF-8 console until script ends
- check PowerShell exit code correctly

## Testing
- `pip install -r requirements.txt`
- `pip install httpx`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d6878ebf48324ab62f5227c5bc4c2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of shortcut creation by more accurately detecting errors during the process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->