### PR TITLE
Improve loading overlay design

### DIFF
--- a/src/modules/ui_utils.py
+++ b/src/modules/ui_utils.py
@@ -18,7 +18,11 @@ def loading_overlay(message: str = "Đang xử lý..."):
     # HTML của overlay hiển thị spinner và thông báo
     overlay_html = f"""
     <div class='loading-overlay'>
-        <div class='loading-spinner'></div>
+        <div class='loading-spinner'>
+            <div class='loading-dot'></div>
+            <div class='loading-dot'></div>
+            <div class='loading-dot'></div>
+        </div>
         <div class='loading-text'>{message}</div>
     </div>
     """

--- a/static/style.css
+++ b/static/style.css
@@ -149,7 +149,8 @@ table.dataframe td {
   left: 0;
   width: 100%;
   height: 100%;
-  background: rgba(0, 0, 0, 0.4);
+  background: rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(3px);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -158,21 +159,34 @@ table.dataframe td {
 }
 
 .loading-spinner {
-  border: 6px solid #f3f3f3;
-  border-top: 6px solid var(--btn-gold);
+  display: flex;
+  align-items: flex-end;
+}
+
+.loading-dot {
+  width: 12px;
+  height: 12px;
+  margin: 0 4px;
+  background: var(--btn-gold);
   border-radius: 50%;
-  width: 60px;
-  height: 60px;
-  animation: spin 1s linear infinite;
+  animation: bounce 1.2s infinite ease-in-out;
+}
+
+.loading-dot:nth-child(2) {
+  animation-delay: -0.3s;
+}
+
+.loading-dot:nth-child(3) {
+  animation-delay: -0.15s;
 }
 
 .loading-text {
   color: var(--btn-text-color);
-  margin-top: 10px;
+  margin-top: 12px;
   font-weight: bold;
 }
 
-@keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
+@keyframes bounce {
+  0%, 80%, 100% { transform: scale(0); }
+  40% { transform: scale(1); }
 }


### PR DESCRIPTION
## Summary
- redesign the loading overlay for better look and feel
- show three bouncing dots for loading animation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d70c9eaf48324872d4a8175760748