### PR TITLE
Improve button design

### DIFF
--- a/src/main_engine/app.py
+++ b/src/main_engine/app.py
@@ -397,13 +397,21 @@ custom_css = f"""
         border-right: 2px solid {accent_color}22;
     }}
     
+    .stButton {{
+        width: 100%;
+        display: flex;
+        justify-content: center;
+        margin: 0.5rem 0;
+    }}
+
     .stButton > button {{
+        min-width: 160px;
         background: linear-gradient(135deg, {accent_color} 0%, {secondary_color} 100%);
         color: var(--btn-text-color);
         border-radius: {border_radius}px;
         border: none;
-        padding: 0.6rem 1.2rem;
-        font-weight: 500;
+        padding: 0.75rem 1.5rem;
+        font-weight: 600;
         font-family: '{font_family}', sans-serif;
         box-shadow: 0 4px 15px {accent_color}33;
         transition: all 0.3s ease;

--- a/static/style.css
+++ b/static/style.css
@@ -86,6 +86,21 @@ div[data-testid="stDataFrame"] {
   font-size: 1.1rem;
 }
 
+/* Improve layout for buttons inside tabs */
+.stTabs .stButton {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  margin: 0.5rem 0;
+}
+
+.stTabs .stButton > button {
+  min-width: 160px;
+  font-size: 1.05rem;
+  font-weight: 600;
+  padding: 0.75rem 1.25rem;
+}
+
 /* Wrap text in DataFrame cells for readability */
 div[data-testid="stDataFrame"] td {
   white-space: pre-wrap !important;


### PR DESCRIPTION
## Summary
- add CSS styles to make tab buttons larger and centered
- tweak Streamlit app button styles with padding and layout improvements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d737ffbf08324a522756810ff4517