### PR TITLE
Add log display overlay for tab actions

### DIFF
--- a/src/main_engine/app.py
+++ b/src/main_engine/app.py
@@ -31,7 +31,6 @@ if __package__ is None:
     __package__ = "main_engine"
 
 import streamlit as st
-from modules.ui_utils import loading_overlay
 from .utils import handle_error, safe_session_state_get, safe_session_state_set
 from .chat import render_enhanced_chat_tab
 from .sidebar import render_sidebar, render_email_config

--- a/src/main_engine/chat.py
+++ b/src/main_engine/chat.py
@@ -8,7 +8,7 @@ import pandas as pd
 import streamlit as st
 
 from modules.config import OUTPUT_CSV
-from modules.ui_utils import loading_overlay
+from modules.ui_utils import loading_logs, display_logs
 from .utils import handle_error, safe_session_state_get
 
 logger = logging.getLogger(__name__)
@@ -142,7 +142,7 @@ def process_chat_message(user_input: str):
             "content": user_input,
             "timestamp": timestamp,
         })
-        with loading_overlay("🤖 AI đang suy nghĩ..."):
+        with loading_logs("🤖 AI đang suy nghĩ...") as log_area:
             from modules.qa_chatbot import QAChatbot
             provider = st.session_state.get("selected_provider", "google")
             model = st.session_state.get("selected_model", "gemini-2.5-flash-lite-preview-06-17")
@@ -175,6 +175,7 @@ def process_chat_message(user_input: str):
                 st.rerun()
             else:
                 st.error("❌ Không thể lấy phản hồi từ AI. Vui lòng thử lại.")
+            display_logs(log_area)
     except Exception as e:
         st.error(f"❌ Lỗi xử lý chat: {e}")
         logger.error("Chat processing error: %s", e)

--- a/src/main_engine/sidebar.py
+++ b/src/main_engine/sidebar.py
@@ -22,7 +22,7 @@ from modules.config import (
     EMAIL_UNSEEN_ONLY,
 )
 from modules.auto_fetcher import watch_loop
-from modules.ui_utils import loading_overlay
+from modules.ui_utils import loading_logs, display_logs
 from .utils import handle_error, safe_session_state_get, safe_session_state_set
 
 # Logger cho file này
@@ -91,14 +91,14 @@ def render_sidebar(validate_configuration, detect_platform, get_available_models
             if not api_key:
                 st.sidebar.warning("⚠️ Vui lòng nhập API Key trước khi lấy models")
             else:
-                with loading_overlay("Đang lấy danh sách models..."):
+                with loading_logs("Đang lấy danh sách models...") as log_area:
                     models = get_available_models(provider, api_key)
                     if models:
-                        # Lưu danh sách models vào session_state
                         safe_session_state_set("available_models", models)
                         st.sidebar.success(f"✅ Đã lấy {len(models)} models")
                     else:
                         st.sidebar.error("❌ Không thể lấy models")
+                    display_logs(log_area)
     with col2:
         # Nút xóa cache models
         if st.button("🗑️", help="Xóa cache models"):

--- a/src/main_engine/tabs/chat_tab.py
+++ b/src/main_engine/tabs/chat_tab.py
@@ -5,7 +5,7 @@ import os
 import pandas as pd
 import streamlit as st
 from typing import cast
-from modules.ui_utils import loading_overlay
+from modules.ui_utils import loading_logs, display_logs
 
 from modules.qa_chatbot import QAChatbot
 from modules.config import OUTPUT_CSV
@@ -37,13 +37,13 @@ def render(provider: str, model: str, api_key: str) -> None:
                 model=cast(str, model),
                 api_key=cast(str, api_key),
             )
-            with loading_overlay("Đang hỏi AI..."):
+            with loading_logs("Đang hỏi AI...") as log_area:
                 try:
                     logging.info("Đang gửi câu hỏi tới AI")
                     answer = chatbot.ask_question(question, df)
-                    # Allow basic HTML in the answer so line breaks and lists
-                    # from the LLM render correctly in Streamlit.
                     st.markdown(answer, unsafe_allow_html=True)
                 except Exception as e:
                     logging.error(f"Lỗi hỏi AI: {e}")
                     st.error(f"Lỗi khi hỏi AI: {e}")
+                finally:
+                    display_logs(log_area)

--- a/src/main_engine/tabs/process_tab.py
+++ b/src/main_engine/tabs/process_tab.py
@@ -13,6 +13,7 @@ from modules.config import (
     get_model_price,
 )
 from modules.dynamic_llm_client import DynamicLLMClient
+from modules.ui_utils import loading_logs, display_logs
 
 
 def render(
@@ -49,8 +50,9 @@ def render(
             llm_client=DynamicLLMClient(provider=provider, model=model, api_key=api_key),
         )
 
-        with st.spinner("Đang xử lý CV..."):
+        with loading_logs("Đang xử lý CV...") as log_area:
             df = processor.process(unseen_only=unseen_only)
+            display_logs(log_area)
 
         if df.empty:
             st.info("Không có CV nào để xử lý.")

--- a/src/main_engine/tabs/single_tab.py
+++ b/src/main_engine/tabs/single_tab.py
@@ -7,7 +7,7 @@ import streamlit as st
 from modules.cv_processor import CVProcessor
 from modules.config import get_model_price
 from modules.dynamic_llm_client import DynamicLLMClient
-from modules.ui_utils import loading_overlay
+from modules.ui_utils import loading_logs, display_logs
 
 
 def render(provider: str, model: str, api_key: str, root: Path) -> None:
@@ -24,7 +24,9 @@ def render(provider: str, model: str, api_key: str, root: Path) -> None:
     if uploaded:
         tmp_file = root / f"tmp_{uploaded.name}"
         tmp_file.write_bytes(uploaded.getbuffer())
-        with loading_overlay(f"Đang trích xuất & phân tích... (LLM: {provider}/{label})"):
+        with loading_logs(
+            f"Đang trích xuất & phân tích... (LLM: {provider}/{label})"
+        ) as log_area:
             logging.info(f"Xử lý file đơn {uploaded.name}")
             proc = CVProcessor(
                 llm_client=DynamicLLMClient(
@@ -35,5 +37,6 @@ def render(provider: str, model: str, api_key: str, root: Path) -> None:
             )
             text = proc.extract_text(str(tmp_file))
             info = proc.extract_info_with_llm(text)
+            display_logs(log_area)
         st.json(info)
         tmp_file.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary
- overlay spinner can now show logs via `loading_logs`
- display logs after long operations in sidebar and tabs
- include new `display_logs` helper

## Testing
- `pytest -q`
- `ruff check .` *(fails: E402, F401, F841, F541)*

------
https://chatgpt.com/codex/tasks/task_e_685d774d093c83248746704a1d8cbb14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced enhanced log display during loading states, providing real-time feedback and detailed logs in various workflows such as chat, model selection, and CV processing.

* **Improvements**
  * Loading overlays have been upgraded to show logs alongside progress indicators, improving transparency and user experience during operations.

* **Bug Fixes**
  * Resolved issues where error logs were not visibly displayed after failed operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->