### PR TITLE
Improve Streamlit themes

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,2 +1,6 @@
 [theme]
 base = "light"
+primaryColor = "#d4af37"
+backgroundColor = "#faf9f6"
+secondaryBackgroundColor = "#f6f1d6"
+textColor = "#222222"

--- a/readme.md
+++ b/readme.md
@@ -219,7 +219,7 @@ streamlit run scripts/simple_app.py
 
 ### 🌙 Dark Mode
 
-Ứng dụng hiện luôn sử dụng giao diện sáng (light theme) để đảm bảo trải nghiệm thống nhất. Nếu muốn bật chế độ tối, bạn cần tự chỉnh sửa mã nguồn.
+Giao diện nay hỗ trợ cả chế độ sáng và tối. Streamlit sẽ áp dụng theme dựa trên cài đặt trong `~/.streamlit/config.toml` hoặc lựa chọn *Appearance* ở menu cài đặt (biểu tượng bánh răng). Theme tối sử dụng tông vàng chủ đạo như chế độ sáng nhưng với nền đen dịu mắt, phù hợp làm việc ban đêm.
 
 ## 🗂️ Cấu trúc dự án
 

--- a/src/main_engine/app.py
+++ b/src/main_engine/app.py
@@ -118,10 +118,10 @@ def initialize_session_state():
     """Initialize session state with safe defaults"""
     defaults = {
         "conversation_history": [],
-        "background_color": "#fffbf0",
-        "text_color": "#000000",
+        "background_color": "#faf9f6",
+        "text_color": "#222222",
         "accent_color": "#d4af37",
-        "secondary_color": "#f4e09c",
+        "secondary_color": "#f6f1d6",
         "font_family_index": 0,
         "font_size": 14,
         "border_radius": 8,
@@ -350,10 +350,10 @@ provider, api_key, model = render_sidebar(
 email_user, email_pass, unseen_only = render_email_config(ROOT, provider, api_key)
 
 # Load style preferences from session state
-background_color = st.session_state.get("background_color", "#fffbf0")
-text_color = st.session_state.get("text_color", "#000000")
+background_color = st.session_state.get("background_color", "#faf9f6")
+text_color = st.session_state.get("text_color", "#222222")
 accent_color = st.session_state.get("accent_color", "#d4af37")
-secondary_color = st.session_state.get("secondary_color", "#f4e09c")
+secondary_color = st.session_state.get("secondary_color", "#f6f1d6")
 font_options = [
     "Be Vietnam Pro",
     "Poppins",

--- a/src/main_engine/chat.py
+++ b/src/main_engine/chat.py
@@ -77,7 +77,7 @@ def render_chat_history():
                 f"""
                 <div style="display: flex; justify-content: flex-end; margin: 10px 0;">
                     <div class="chat-message" style="
-                        background: linear-gradient(135deg, {st.session_state.get('accent_color', '#d4af37')} 0%, {st.session_state.get('secondary_color', '#f4e09c')} 100%);
+                        background: linear-gradient(135deg, {st.session_state.get('accent_color', '#d4af37')} 0%, {st.session_state.get('secondary_color', '#f6f1d6')} 100%);
                         color: white;
                         margin-left: 20%;
                     ">
@@ -96,9 +96,9 @@ def render_chat_history():
                 f"""
                 <div style="display: flex; justify-content: flex-start; margin:10px 0;">
                     <div class="chat-message" style="
-                        background: linear-gradient(135deg, {st.session_state.get('background_color', '#fffbf0')} 0%, {st.session_state.get('secondary_color', '#f4e09c')}44 100%);
-                        color: {st.session_state.get('text_color', '#000000')};
-                        border: 2px solid {st.session_state.get('secondary_color', '#f4e09c')};
+                        background: linear-gradient(135deg, {st.session_state.get('background_color', '#faf9f6')} 0%, {st.session_state.get('secondary_color', '#f6f1d6')}44 100%);
+                        color: {st.session_state.get('text_color', '#222222')};
+                        border: 2px solid {st.session_state.get('secondary_color', '#f6f1d6')};
                         margin-right: 20%;
                     ">
                         <strong>🤖 AI:</strong><br>

--- a/static/style.css
+++ b/static/style.css
@@ -1,20 +1,20 @@
 /* static/style.css */
-@import url('https://fonts.googleapis.com/css2?family=Be+Vietnam+Pro:wght@300;400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Be+Vietnam+Pro:wght@300;400;500;600;700&family=Poppins:wght@300;400;500;600;700&display=swap');
 
 /* Simple theme variables */
 :root[data-theme="light"] {
-  --cv-text-color: #000000;
-  --cv-bg-color: #fffbf0;
-  --cv-accent-color: #f4e09c;
+  --cv-text-color: #222222;
+  --cv-bg-color: #faf9f6;
+  --cv-accent-color: #f6f1d6;
   --btn-gold: #d4af37;
   --btn-gold-border: #d4af37;
-  --btn-text-color: #000000;
+  --btn-text-color: #222222;
 }
 
 :root[data-theme="dark"] {
-  --cv-text-color: #f0f0f0;
-  --cv-bg-color: #121212;
-  --cv-accent-color: #333333;
+  --cv-text-color: #e6e6e6;
+  --cv-bg-color: #181818;
+  --cv-accent-color: #252525;
   --btn-gold: #d4af37;
   --btn-gold-border: #d4af37;
   --btn-text-color: #ffffff;
@@ -29,7 +29,8 @@ body {
   background-color: var(--cv-bg-color) !important;
   color: var(--cv-text-color) !important;
   font-size: 0.95rem;
-  font-family: 'Be Vietnam Pro', sans-serif;
+  font-family: 'Poppins', 'Be Vietnam Pro', sans-serif;
+  transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 /* Button styling for BaseWeb buttons */


### PR DESCRIPTION
## Summary
- tweak default light colors and fonts
- add dark theme palette
- update config example and README instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d7851b444832482515d06f59d0904