### PR TITLE
Improve log overlay

### DIFF
--- a/src/main_engine/app.py
+++ b/src/main_engine/app.py
@@ -162,6 +162,18 @@ class StreamlitLogHandler(logging.Handler):
             )
             safe_session_state_set("logs", logs)
 
+            # Cập nhật overlay log realtime nếu có
+            overlay_updater = safe_session_state_get("log_overlay_updater")
+            if callable(overlay_updater):
+                recent_logs = logs[-10:]
+                log_text = "\n".join(
+                    f"[{e.get('timestamp','')}] {e.get('level','')}: {e.get('message','')}" for e in recent_logs
+                )
+                try:
+                    overlay_updater(log_text)
+                except Exception:
+                    pass
+
         except Exception as e:
             # Fallback to standard logging if Streamlit fails
             print(f"StreamlitLogHandler error: {e}")

--- a/src/main_engine/chat.py
+++ b/src/main_engine/chat.py
@@ -8,7 +8,7 @@ import pandas as pd
 import streamlit as st
 
 from modules.config import OUTPUT_CSV
-from modules.ui_utils import loading_logs, display_logs
+from modules.ui_utils import loading_logs
 from .utils import handle_error, safe_session_state_get
 
 logger = logging.getLogger(__name__)
@@ -142,7 +142,7 @@ def process_chat_message(user_input: str):
             "content": user_input,
             "timestamp": timestamp,
         })
-        with loading_logs("🤖 AI đang suy nghĩ...") as log_area:
+        with loading_logs("🤖 AI đang suy nghĩ..."):
             from modules.qa_chatbot import QAChatbot
             provider = st.session_state.get("selected_provider", "google")
             model = st.session_state.get("selected_model", "gemini-2.5-flash-lite-preview-06-17")
@@ -175,7 +175,6 @@ def process_chat_message(user_input: str):
                 st.rerun()
             else:
                 st.error("❌ Không thể lấy phản hồi từ AI. Vui lòng thử lại.")
-            display_logs(log_area)
     except Exception as e:
         st.error(f"❌ Lỗi xử lý chat: {e}")
         logger.error("Chat processing error: %s", e)

--- a/src/main_engine/sidebar.py
+++ b/src/main_engine/sidebar.py
@@ -22,7 +22,7 @@ from modules.config import (
     EMAIL_UNSEEN_ONLY,
 )
 from modules.auto_fetcher import watch_loop
-from modules.ui_utils import loading_logs, display_logs
+from modules.ui_utils import loading_logs
 from .utils import handle_error, safe_session_state_get, safe_session_state_set
 
 # Logger cho file này
@@ -91,14 +91,13 @@ def render_sidebar(validate_configuration, detect_platform, get_available_models
             if not api_key:
                 st.sidebar.warning("⚠️ Vui lòng nhập API Key trước khi lấy models")
             else:
-                with loading_logs("Đang lấy danh sách models...") as log_area:
+                with loading_logs("Đang lấy danh sách models..."):
                     models = get_available_models(provider, api_key)
                     if models:
                         safe_session_state_set("available_models", models)
                         st.sidebar.success(f"✅ Đã lấy {len(models)} models")
                     else:
                         st.sidebar.error("❌ Không thể lấy models")
-                    display_logs(log_area)
     with col2:
         # Nút xóa cache models
         if st.button("🗑️", help="Xóa cache models"):

--- a/src/main_engine/tabs/chat_tab.py
+++ b/src/main_engine/tabs/chat_tab.py
@@ -5,7 +5,7 @@ import os
 import pandas as pd
 import streamlit as st
 from typing import cast
-from modules.ui_utils import loading_logs, display_logs
+from modules.ui_utils import loading_logs
 
 from modules.qa_chatbot import QAChatbot
 from modules.config import OUTPUT_CSV
@@ -37,7 +37,7 @@ def render(provider: str, model: str, api_key: str) -> None:
                 model=cast(str, model),
                 api_key=cast(str, api_key),
             )
-            with loading_logs("Đang hỏi AI...") as log_area:
+            with loading_logs("Đang hỏi AI..."):
                 try:
                     logging.info("Đang gửi câu hỏi tới AI")
                     answer = chatbot.ask_question(question, df)
@@ -45,5 +45,3 @@ def render(provider: str, model: str, api_key: str) -> None:
                 except Exception as e:
                     logging.error(f"Lỗi hỏi AI: {e}")
                     st.error(f"Lỗi khi hỏi AI: {e}")
-                finally:
-                    display_logs(log_area)

--- a/src/main_engine/tabs/process_tab.py
+++ b/src/main_engine/tabs/process_tab.py
@@ -13,7 +13,7 @@ from modules.config import (
     get_model_price,
 )
 from modules.dynamic_llm_client import DynamicLLMClient
-from modules.ui_utils import loading_logs, display_logs
+from modules.ui_utils import loading_logs
 
 
 def render(
@@ -50,9 +50,8 @@ def render(
             llm_client=DynamicLLMClient(provider=provider, model=model, api_key=api_key),
         )
 
-        with loading_logs("Đang xử lý CV...") as log_area:
+        with loading_logs("Đang xử lý CV..."):
             df = processor.process(unseen_only=unseen_only)
-            display_logs(log_area)
 
         if df.empty:
             st.info("Không có CV nào để xử lý.")

--- a/src/main_engine/tabs/single_tab.py
+++ b/src/main_engine/tabs/single_tab.py
@@ -7,7 +7,7 @@ import streamlit as st
 from modules.cv_processor import CVProcessor
 from modules.config import get_model_price
 from modules.dynamic_llm_client import DynamicLLMClient
-from modules.ui_utils import loading_logs, display_logs
+from modules.ui_utils import loading_logs
 
 
 def render(provider: str, model: str, api_key: str, root: Path) -> None:
@@ -26,7 +26,7 @@ def render(provider: str, model: str, api_key: str, root: Path) -> None:
         tmp_file.write_bytes(uploaded.getbuffer())
         with loading_logs(
             f"Đang trích xuất & phân tích... (LLM: {provider}/{label})"
-        ) as log_area:
+        ):
             logging.info(f"Xử lý file đơn {uploaded.name}")
             proc = CVProcessor(
                 llm_client=DynamicLLMClient(
@@ -37,6 +37,5 @@ def render(provider: str, model: str, api_key: str, root: Path) -> None:
             )
             text = proc.extract_text(str(tmp_file))
             info = proc.extract_info_with_llm(text)
-            display_logs(log_area)
         st.json(info)
         tmp_file.unlink(missing_ok=True)

--- a/src/modules/ui_utils.py
+++ b/src/modules/ui_utils.py
@@ -58,24 +58,31 @@ def display_logs(container: st.delta_generator.DeltaGenerator, max_lines: int = 
 
 @contextmanager
 def loading_logs(message: str = "Đang xử lý..."):
-    """Overlay loading kèm container hiển thị log."""
+    """Overlay loading hiển thị log realtime."""
     overlay = st.empty()
-    log_container = st.empty()
-    overlay_html = f"""
-    <div class='loading-overlay'>
-        <div class='loading-spinner'>
-            <div class='loading-dot'></div>
-            <div class='loading-dot'></div>
-            <div class='loading-dot'></div>
+
+    def render(log_text: str = "") -> None:
+        overlay_html = f"""
+        <div class='loading-overlay'>
+            <div class='loading-spinner'>
+                <div class='loading-dot'></div>
+                <div class='loading-dot'></div>
+                <div class='loading-dot'></div>
+            </div>
+            <div class='loading-text'>{message}</div>
+            <pre class='loading-log'>{log_text}</pre>
         </div>
-        <div class='loading-text'>{message}</div>
-    </div>
-    """
-    overlay.markdown(overlay_html, unsafe_allow_html=True)
+        """
+        overlay.markdown(overlay_html, unsafe_allow_html=True)
+
+    # Lưu hàm cập nhật overlay vào session_state để handler có thể gọi
+    st.session_state["log_overlay_updater"] = render
+    render()
     try:
-        yield log_container
+        yield overlay
     finally:
         overlay.empty()
+        st.session_state.pop("log_overlay_updater", None)
 
 
 __all__ = ["loading_overlay", "loading_logs", "display_logs"]

--- a/static/style.css
+++ b/static/style.css
@@ -201,6 +201,20 @@ table.dataframe td {
   font-weight: bold;
 }
 
+.loading-log {
+  color: var(--btn-text-color);
+  background: rgba(0, 0, 0, 0.2);
+  font-family: monospace;
+  font-size: 0.8rem;
+  margin-top: 8px;
+  padding: 8px;
+  border-radius: 4px;
+  max-height: 200px;
+  overflow-y: auto;
+  width: 90%;
+  white-space: pre-wrap;
+}
+
 @keyframes bounce {
   0%, 80%, 100% { transform: scale(0); }
   40% { transform: scale(1); }


### PR DESCRIPTION
## Summary
- style log overlay via new `.loading-log` class
- show realtime logs in loading overlay
- remove old log display

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d799ff9208324978aec92c49f1f80