### PR TITLE
Improve loading spinner UI

### DIFF
--- a/src/modules/ui_utils.py
+++ b/src/modules/ui_utils.py
@@ -18,11 +18,7 @@ def loading_overlay(message: str = "Đang xử lý..."):
     # HTML của overlay hiển thị spinner và thông báo
     overlay_html = f"""
     <div class='loading-overlay'>
-        <div class='loading-spinner'>
-            <div class='loading-dot'></div>
-            <div class='loading-dot'></div>
-            <div class='loading-dot'></div>
-        </div>
+        <div class='loading-ring'></div>
         <div class='loading-text'>{message}</div>
     </div>
     """
@@ -64,11 +60,7 @@ def loading_logs(message: str = "Đang xử lý..."):
     def render(log_text: str = "") -> None:
         overlay_html = f"""
         <div class='loading-overlay'>
-            <div class='loading-spinner'>
-                <div class='loading-dot'></div>
-                <div class='loading-dot'></div>
-                <div class='loading-dot'></div>
-            </div>
+            <div class='loading-ring'></div>
             <div class='loading-text'>{message}</div>
             <pre class='loading-log'>{log_text}</pre>
         </div>

--- a/static/style.css
+++ b/static/style.css
@@ -174,26 +174,14 @@ table.dataframe td {
   z-index: 9999;
 }
 
-.loading-spinner {
-  display: flex;
-  align-items: flex-end;
-}
-
-.loading-dot {
-  width: 12px;
-  height: 12px;
-  margin: 0 4px;
-  background: var(--btn-gold);
+.loading-ring {
+  width: 48px;
+  height: 48px;
+  border: 6px solid var(--btn-gold);
+  border-color: var(--btn-gold) transparent var(--btn-gold) transparent;
   border-radius: 50%;
-  animation: bounce 1.2s infinite ease-in-out;
-}
-
-.loading-dot:nth-child(2) {
-  animation-delay: -0.3s;
-}
-
-.loading-dot:nth-child(3) {
-  animation-delay: -0.15s;
+  animation: loading-spin 1.2s linear infinite;
+  margin-bottom: 12px;
 }
 
 .loading-text {
@@ -216,7 +204,7 @@ table.dataframe td {
   white-space: pre-wrap;
 }
 
-@keyframes bounce {
-  0%, 80%, 100% { transform: scale(0); }
-  40% { transform: scale(1); }
+@keyframes loading-spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
 }


### PR DESCRIPTION
## Summary
- refresh loading overlay design with a spinning ring

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685debf6b8b48324b740fffe80d82321