### PR TITLE
Improve attachment table UI

### DIFF
--- a/src/main_engine/tabs/fetch_tab.py
+++ b/src/main_engine/tabs/fetch_tab.py
@@ -3,6 +3,8 @@
 import logging
 from typing import List
 from pathlib import Path
+import base64
+import pandas as pd
 import streamlit as st
 
 from modules.config import (
@@ -12,6 +14,8 @@ from modules.config import (
     SENT_TIME_FILE,
 )
 from modules.email_fetcher import EmailFetcher
+from modules.sent_time_store import load_sent_times
+from modules.cv_processor import format_sent_time_display
 
 
 def render(email_user: str, email_pass: str, unseen_only: bool) -> None:
@@ -44,11 +48,34 @@ def render(email_user: str, email_pass: str, unseen_only: bool) -> None:
             and p.suffix.lower() in (".pdf", ".docx")
         )
         if attachments:
-            items = "".join(f"<li>{Path(p).name}</li>" for p in attachments)
-            list_html = f"<ul>{items}</ul>"
+            sent_map = load_sent_times()
+
+            def make_link(path: Path) -> str:
+                data = base64.b64encode(path.read_bytes()).decode()
+                mime = (
+                    "application/pdf"
+                    if path.suffix.lower() == ".pdf"
+                    else "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+                )
+                return (
+                    f'<a download="{path.name}" href="data:{mime};base64,{data}">{path.name}</a>'
+                )
+
+            rows = []
+            for p in attachments:
+                sent = format_sent_time_display(sent_map.get(p.name, ""))
+                size_kb = p.stat().st_size / 1024
+                rows.append({
+                    "File": make_link(p),
+                    "Dung lượng": f"{size_kb:.1f} KB",
+                    "Gửi lúc": sent,
+                })
+
+            df = pd.DataFrame(rows, columns=["File", "Dung lượng", "Gửi lúc"])
+            table_html = df.to_html(escape=False, index=False)
             styled_html = (
-                "<div style='max-height: 400px; overflow-y: auto; overflow-x: auto;'>"
-                f"{list_html}"
+                "<div class='attachments-table-container' style='max-height: 400px; overflow:auto;'>"
+                f"{table_html}"
                 "</div>"
             )
             st.markdown(styled_html, unsafe_allow_html=True)

--- a/static/style.css
+++ b/static/style.css
@@ -158,6 +158,30 @@ table.dataframe td {
 .results-table-container tbody tr:hover {
   background-color: rgba(0, 0, 0, 0.08);
 }
+
+/* Attachment table styling */
+.attachments-table-container {
+  overflow: auto;
+  max-height: 400px;
+}
+.attachments-table-container table.dataframe {
+  width: 100%;
+  table-layout: auto;
+  border-collapse: collapse;
+}
+.attachments-table-container th {
+  position: sticky;
+  top: 0;
+  background-color: var(--btn-gold);
+  color: var(--btn-text-color);
+  z-index: 1;
+}
+.attachments-table-container tbody tr:nth-child(even) {
+  background-color: rgba(0, 0, 0, 0.04);
+}
+.attachments-table-container tbody tr:hover {
+  background-color: rgba(0, 0, 0, 0.08);
+}
 /* Loading overlay styles */
 .loading-overlay {
   position: fixed;


### PR DESCRIPTION
## Summary
- display attachments as a table with download links, file size and time
- style the new attachments table in CSS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dec3c46788324825000b984a18081