### PR TITLE
Improve loading overlay

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -187,15 +187,17 @@ table.dataframe td {
   position: fixed;
   top: 0;
   left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0.35);
+  right: 0;
+  bottom: 0;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(0, 0, 0, 0.25);
   backdrop-filter: blur(3px);
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  z-index: 9999;
+  z-index: 100000;
 }
 
 .loading-ring {
@@ -216,7 +218,7 @@ table.dataframe td {
 
 .loading-log {
   color: var(--btn-text-color);
-  background: rgba(0, 0, 0, 0.2);
+  background: rgba(0, 0, 0, 0.15);
   font-family: monospace;
   font-size: 0.8rem;
   margin-top: 8px;


### PR DESCRIPTION
## Summary
- lighten overlay and log backgrounds
- ensure log overlay covers full page

## Testing
- `pip install -q -r requirements-dev.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685df82e374c8324bf76a7a8faed8fd9