### PR TITLE
Improve loading overlay style

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -198,19 +198,21 @@ table.dataframe td {
   align-items: center;
   justify-content: center;
   z-index: 100000;
+  animation: fade-in 0.3s ease-out;
 }
 
 .loading-ring {
   position: relative;
   box-sizing: border-box;
-  width: 48px;
-  height: 48px;
+  width: 60px;
+  height: 60px;
   border: 6px solid transparent;
   border-top-color: var(--btn-gold);
   border-left-color: var(--btn-gold);
   border-radius: 50%;
-  animation: loading-spin 1s linear infinite;
+  animation: loading-spin 1s linear infinite, pulse-glow 1.5s ease-in-out infinite;
   margin-bottom: 12px;
+  box-shadow: 0 0 8px rgba(212, 175, 55, 0.4);
 }
 
 .loading-ring::after {
@@ -224,13 +226,15 @@ table.dataframe td {
   border-bottom-color: var(--btn-text-color);
   border-right-color: var(--btn-text-color);
   border-radius: 50%;
-  animation: loading-spin 0.8s linear infinite reverse;
+  animation: loading-spin 0.8s linear infinite reverse, pulse-glow 1.5s ease-in-out infinite;
 }
 
 .loading-text {
   color: var(--btn-text-color);
   margin-top: 12px;
   font-weight: bold;
+  letter-spacing: 0.05em;
+  text-shadow: 0 0 4px rgba(212, 175, 55, 0.6);
 }
 
 .loading-log {
@@ -250,4 +254,14 @@ table.dataframe td {
 @keyframes loading-spin {
   0% { transform: rotate(0deg); }
   100% { transform: rotate(360deg); }
+}
+
+@keyframes pulse-glow {
+  0%, 100% { box-shadow: 0 0 8px rgba(212, 175, 55, 0.4); }
+  50% { box-shadow: 0 0 18px rgba(212, 175, 55, 0.8); }
+}
+
+@keyframes fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
 }


### PR DESCRIPTION
## Summary
- animate loading overlay with a fade-in
- add glow effect to the loading spinner
- tweak loading text styling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_685dfe5030bc8324b095541b3ef496ad