### PR TITLE
Add CV links next to candidate names

### DIFF
--- a/test/test_name_cv_link.py
+++ b/test/test_name_cv_link.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / 'src'))
+
+import modules.qa_chatbot as qc
+
+
+def test_name_cv_link(tmp_path, monkeypatch):
+    class DummyClient:
+        def __init__(self, *a, **k):
+            pass
+        def generate_content(self, msgs):
+            return "Alice là ứng viên tiềm năng."
+    monkeypatch.setattr(qc, 'DynamicLLMClient', DummyClient)
+    monkeypatch.setattr(qc, 'ATTACHMENT_DIR', tmp_path)
+    (tmp_path / 'alice.pdf').write_text('data')
+    df = pd.DataFrame([{'Họ tên': 'Alice', 'Nguồn': 'alice.pdf'}])
+    ans = qc.answer_question('Alice?', df, provider='p', model='m', api_key='key')
+    assert 'download="alice.pdf"' in ans


### PR DESCRIPTION
## Summary
- attach CV download links whenever a candidate name is mentioned by the chatbot
- test that name linking works

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e01247c5883249ff57a6fd6f6459e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Candidate names mentioned in AI-generated answers are now automatically linked to their corresponding CV file download links when available.

* **Tests**
  * Added a test to verify that candidate names in answers are correctly linked to their CV files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->