### PR TITLE
Enable scrollbars for all results table columns

### DIFF
--- a/src/main_engine/tabs/results_tab.py
+++ b/src/main_engine/tabs/results_tab.py
@@ -35,12 +35,11 @@ def render() -> None:
         if "Nguồn" in df.columns:
             df["Nguồn"] = df["Nguồn"].apply(make_link)
 
-        # Wrap long text fields with a scrollable container
-        for col in ["Học vấn", "Kinh nghiệm", "Kỹ năng"]:
-            if col in df.columns:
-                df[col] = df[col].apply(
-                    lambda v: f"<div class='cell-scroll'>{v}</div>" if pd.notna(v) else ""
-                )
+        # Wrap all columns so long text becomes scrollable
+        for col in df.columns:
+            df[col] = df[col].apply(
+                lambda v: f"<div class='cell-scroll'>{v}</div>" if pd.notna(v) else ""
+            )
 
         table_html = df.to_html(escape=False, index=False)
         styled_html = (


### PR DESCRIPTION
## Summary
- wrap all columns with `cell-scroll` containers
- existing CSS already applies max-height and overflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e01bfaf9483249a640b2b75dc056e