### PR TITLE
Update date filter format

### DIFF
--- a/scripts/cli_agent.py
+++ b/scripts/cli_agent.py
@@ -32,8 +32,8 @@ def cli():
 @click.option('--port', default=lambda: settings.email_port, type=int, help='IMAP port')
 @click.option('--user', default=lambda: settings.email_user, help='Email user')
 @click.option('--password', default=lambda: settings.email_pass, help='Email password')
-@click.option('--from-date', type=click.DateTime(formats=['%Y-%m-%d']), help='Chỉ lấy email từ ngày này (YYYY-MM-DD)')
-@click.option('--to-date', type=click.DateTime(formats=['%Y-%m-%d']), help='Chỉ lấy email trước ngày này (YYYY-MM-DD)')
+@click.option('--from-date', type=click.DateTime(formats=['%d/%m/%Y']), help='Chỉ lấy email từ ngày này (DD/MM/YYYY)')
+@click.option('--to-date', type=click.DateTime(formats=['%d/%m/%Y']), help='Chỉ lấy email trước ngày này (DD/MM/YYYY)')
 @click.option('--unseen/--all', 'unseen_only', default=settings.email_unseen_only, show_default=True, help='Chỉ quét email chưa đọc')
 def watch(interval, host, port, user, password, from_date, to_date, unseen_only):
     """Tự động fetch CV từ email liên tục"""
@@ -50,8 +50,8 @@ def watch(interval, host, port, user, password, from_date, to_date, unseen_only)
     )
 
 @cli.command()
-@click.option('--from-date', type=click.DateTime(formats=['%Y-%m-%d']), help='Chỉ lấy email từ ngày này (YYYY-MM-DD)')
-@click.option('--to-date', type=click.DateTime(formats=['%Y-%m-%d']), help='Chỉ lấy email trước ngày này (YYYY-MM-DD)')
+@click.option('--from-date', type=click.DateTime(formats=['%d/%m/%Y']), help='Chỉ lấy email từ ngày này (DD/MM/YYYY)')
+@click.option('--to-date', type=click.DateTime(formats=['%d/%m/%Y']), help='Chỉ lấy email trước ngày này (DD/MM/YYYY)')
 @click.option('--unseen/--all', 'unseen_only', default=settings.email_unseen_only, show_default=True, help='Chỉ quét email chưa đọc')
 def full_process(from_date, to_date, unseen_only):
     """Chạy đầy đủ quy trình fetch và xử lý CV"""

--- a/scripts/simple_app.py
+++ b/scripts/simple_app.py
@@ -3,7 +3,7 @@ import sys
 from pathlib import Path
 import pandas as pd
 import streamlit as st
-from datetime import date
+from datetime import date, datetime
 
 # Ensure the project's `src` directory is on sys.path so that the local
 # `modules` package can be imported when running this script directly.
@@ -61,9 +61,9 @@ email_pass = st.text_input(
 unseen_only = st.checkbox("Chỉ quét email chưa đọc", value=True)
 col1, col2 = st.columns(2)
 with col1:
-    from_date_str = st.text_input("From (YYYY-MM-DD)", value="")
+    from_date_str = st.text_input("From (DD/MM/YYYY)", value="")
 with col2:
-    to_date_str = st.text_input("To (YYYY-MM-DD)", value="")
+    to_date_str = st.text_input("To (DD/MM/YYYY)", value="")
 
 if st.button("Fetch CV"):
     if not email_user or not email_pass:
@@ -71,8 +71,16 @@ if st.button("Fetch CV"):
     else:
         fetcher = EmailFetcher(EMAIL_HOST, EMAIL_PORT, email_user, email_pass)
         fetcher.connect()
-        since = date.fromisoformat(from_date_str) if from_date_str else None
-        before = date.fromisoformat(to_date_str) if to_date_str else None
+        since = (
+            datetime.strptime(from_date_str, "%d/%m/%Y").date()
+            if from_date_str
+            else None
+        )
+        before = (
+            datetime.strptime(to_date_str, "%d/%m/%Y").date()
+            if to_date_str
+            else None
+        )
         files = fetcher.fetch_cv_attachments(
             since=since,
             before=before,

--- a/src/modules/auto_fetcher.py
+++ b/src/modules/auto_fetcher.py
@@ -5,7 +5,7 @@ import time
 import logging
 import argparse
 import imaplib
-from datetime import date
+from datetime import date, datetime
 
 from .config import EMAIL_UNSEEN_ONLY
 
@@ -68,13 +68,13 @@ def main():
     parser.add_argument("--password")
     parser.add_argument(
         "--from-date",
-        type=lambda s: date.fromisoformat(s),
-        help="Chỉ lấy email từ ngày này (YYYY-MM-DD)",
+        type=lambda s: datetime.strptime(s, "%d/%m/%Y").date(),
+        help="Chỉ lấy email từ ngày này (DD/MM/YYYY)",
     )
     parser.add_argument(
         "--to-date",
-        type=lambda s: date.fromisoformat(s),
-        help="Chỉ lấy email trước ngày này (YYYY-MM-DD)",
+        type=lambda s: datetime.strptime(s, "%d/%m/%Y").date(),
+        help="Chỉ lấy email trước ngày này (DD/MM/YYYY)",
     )
     parser.add_argument(
         "--all",

--- a/src/modules/mcp_server.py
+++ b/src/modules/mcp_server.py
@@ -5,7 +5,7 @@ import logging                   # ghi log hoạt động ứng dụng
 from pathlib import Path         # thao tác đường dẫn hướng đối tượng
 
 from fastapi import FastAPI, UploadFile, File, HTTPException  # framework API và xử lý upload
-from datetime import date
+from datetime import date, datetime
 from fastapi.responses import FileResponse    # trả về file như response
 from pydantic_settings import BaseSettings, SettingsConfigDict      # sử dụng BaseSettings với cấu hình cho Pydantic v2
 
@@ -87,8 +87,12 @@ async def run_full(from_date: str | None = None, to_date: str | None = None):
     )
     fetcher.connect()
 
-    since = date.fromisoformat(from_date) if from_date else None
-    before = date.fromisoformat(to_date) if to_date else None
+    since = (
+        datetime.strptime(from_date, "%d/%m/%Y").date() if from_date else None
+    )
+    before = (
+        datetime.strptime(to_date, "%d/%m/%Y").date() if to_date else None
+    )
 
     # Xử lý CV từ fetcher
     processor = CVProcessor(fetcher, llm_client=LLMClient())


### PR DESCRIPTION
## Summary
- parse CLI date arguments as `DD/MM/YYYY`
- update simple_app text inputs to `DD/MM/YYYY`
- accept `DD/MM/YYYY` date format in auto fetcher
- allow MCP server date params in `DD/MM/YYYY`

## Testing
- `pytest -q` *(fails: NameError in cv_processor)*

------
https://chatgpt.com/codex/tasks/task_e_68655231c1dc8324990879e1f994cee7