### PR TITLE
Improve email fetch speed

### DIFF
--- a/src/modules/config.py
+++ b/src/modules/config.py
@@ -97,6 +97,11 @@ SENT_TIME_FILE = _clean_path(
     "SENT_TIME_FILE",
     str(ATTACHMENT_DIR / "sent_times.json")
 )
+# File lưu UID email đã xử lý cuối cùng
+LAST_UID_FILE = _clean_path(
+    "LAST_UID_FILE",
+    str(ATTACHMENT_DIR / "last_uid.txt")
+)
 # File lưu log hội thoại chat
 CHAT_LOG_FILE = _clean_path("CHAT_LOG_FILE", str(LOG_DIR / "chat_log.json"))
 # tạo thư mục nếu chưa tồn tại
@@ -245,6 +250,7 @@ def ensure_directories():
         LOG_DIR,
         CHAT_LOG_FILE.parent,
         LOG_FILE.parent,
+        LAST_UID_FILE.parent,
     ]
     for directory in directories:
         try:

--- a/src/modules/uid_store.py
+++ b/src/modules/uid_store.py
@@ -1,0 +1,22 @@
+"""Store and load the last processed email UID to speed up future fetches."""
+
+from .config import LAST_UID_FILE
+
+
+def load_last_uid() -> int:
+    """Return the last processed UID or 0 if unavailable."""
+    try:
+        if LAST_UID_FILE.exists():
+            content = LAST_UID_FILE.read_text(encoding="utf-8").strip()
+            return int(content or 0)
+    except Exception:
+        return 0
+    return 0
+
+
+def save_last_uid(uid: int) -> None:
+    """Persist the given UID."""
+    try:
+        LAST_UID_FILE.write_text(str(uid), encoding="utf-8")
+    except Exception:
+        pass


### PR DESCRIPTION
## Summary
- persist last processed UID to reduce repeated scanning
- track UID when fetching emails
- store UID in new `uid_store.py`
- adjust email fetcher tests for new behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865d61ddf608324ac8d481c57eca2d1