### PR TITLE
Set default placeholder for to-date fields

### DIFF
--- a/src/main_engine/tabs/fetch_tab.py
+++ b/src/main_engine/tabs/fetch_tab.py
@@ -3,7 +3,7 @@
 import logging
 from typing import List
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, date
 import base64
 import pandas as pd
 import streamlit as st
@@ -33,10 +33,13 @@ def render(email_user: str, email_pass: str, unseen_only: bool) -> None:
             "Auto fetch đang chạy ngầm. Bạn có thể nhấn 'Fetch Now' để kiểm tra ngay."
         )
         col1, col2 = st.columns(2)
+        today_str = date.today().strftime("%d/%m/%Y")
         with col1:
             from_date_str = st.text_input("From (DD/MM/YYYY)", value="")
         with col2:
-            to_date_str = st.text_input("To (DD/MM/YYYY)", value="")
+            to_date_str = st.text_input(
+                "To (DD/MM/YYYY)", value="", placeholder=today_str
+            )
         if st.button("Fetch Now", help="Quét email ngay để tải CV"):
             logging.info("Thực hiện fetch email thủ công")
             with loading_logs("Đang quét email..."):

--- a/src/main_engine/tabs/process_tab.py
+++ b/src/main_engine/tabs/process_tab.py
@@ -1,7 +1,7 @@
 """Tab xử lý hàng loạt file CV."""
 
 import logging
-from datetime import datetime, time, timezone
+from datetime import datetime, time, timezone, date
 import streamlit as st
 
 from modules.cv_processor import CVProcessor
@@ -32,10 +32,13 @@ def render(
     st.markdown(f"**LLM:** `{provider}` / `{label}`")
 
     col1, col2 = st.columns(2)
+    today_str = date.today().strftime("%d/%m/%Y")
     with col1:
         from_date_str = st.text_input("From date (DD/MM/YYYY)", value="", key="cv_from")
     with col2:
-        to_date_str = st.text_input("To date (DD/MM/YYYY)", value="", key="cv_to")
+        to_date_str = st.text_input(
+            "To date (DD/MM/YYYY)", value="", key="cv_to", placeholder=today_str
+        )
 
     if st.button(
         "Bắt đầu xử lý CV",


### PR DESCRIPTION
## Summary
- show today's date as placeholder for `To` date in the fetch email tab
- show today's date as placeholder for `To date` in the CV processing tab

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865d951019c8324b9e007b3bc53abf7