### PR TITLE
Fix timezone imports

### DIFF
--- a/src/main_engine/tabs/process_tab.py
+++ b/src/main_engine/tabs/process_tab.py
@@ -53,7 +53,7 @@ def render(
             datetime.combine(
                 datetime.strptime(from_date_str, "%d/%m/%Y"),
                 time.min,
-                tzinfo=datetime.timezone.utc,
+                tzinfo=timezone.utc,
             )
             if from_date_str
             else None
@@ -62,7 +62,7 @@ def render(
             datetime.combine(
                 datetime.strptime(to_date_str, "%d/%m/%Y"),
                 time.max,
-                tzinfo=datetime.timezone.utc,
+                tzinfo=timezone.utc,
             )
             if to_date_str
             else None

--- a/src/modules/email_fetcher.py
+++ b/src/modules/email_fetcher.py
@@ -202,7 +202,7 @@ class EmailFetcher:
                         try:
                             tup = imaplib.Internaldate2tuple(f'INTERNALDATE "{internal_date}"'.encode())
                             if tup:
-                                dt = datetime.fromtimestamp(time.mktime(tup), tz=datetime.timezone.utc)
+                                dt = datetime.fromtimestamp(time.mktime(tup), tz=timezone.utc)
                                 sent_time = dt.isoformat()
                         except Exception:
                             sent_time = ""


### PR DESCRIPTION
## Summary
- correct timezone usage in `process_tab` and `email_fetcher`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865dab2f95c8324a59ad29fc6c2431b