### PR TITLE
Improve CV position extraction

### DIFF
--- a/src/modules/cv_processor.py
+++ b/src/modules/cv_processor.py
@@ -211,6 +211,7 @@ class CVProcessor:
             "kinh_nghiem": r"(?:(?:Kinh nghiệm|Experience)[:\-\s]+)([^\n]+)",
             "dia_chi": r"(?:(?:Địa chỉ|Address)[:\-\s]+)([^\n]+)",
             "ky_nang": r"(?:(?:Kỹ năng|Skills?)[:\-\s]+)([^\n]+)",
+            "vi_tri": r"(?:(?:Vị trí|Position|Apply for|Ứng tuyển)[:\-\s]+)([^\n]+)",
         }
         info: Dict[str, str] = {}
         for k, p in patterns.items():
@@ -245,12 +246,15 @@ class CVProcessor:
             if progress_callback:
                 progress_callback(0, 100, "📧 Kết nối email...")
             
-            files: List[str] = self.fetcher.fetch_cv_attachments(
-                since=since,
-                before=before,
-                unseen_only=unseen,
-                progress_callback=email_progress_callback,
-            )
+            fetch_args = dict(since=since, before=before, unseen_only=unseen)
+            # Tương thích với các fetcher cũ không nhận progress_callback
+            import inspect
+            if 'progress_callback' in inspect.signature(
+                self.fetcher.fetch_cv_attachments
+            ).parameters:
+                fetch_args['progress_callback'] = email_progress_callback
+
+            files: List[str] = self.fetcher.fetch_cv_attachments(**fetch_args)
         else:
             files = []
             if progress_callback:

--- a/src/modules/prompts.py
+++ b/src/modules/prompts.py
@@ -2,10 +2,10 @@
 
 # Định nghĩa prompt cho LLM để trích xuất thông tin từ CV
 # Yêu cầu kết quả trả về dưới dạng JSON với các khóa:
-#   ten, tuoi, email, dien_thoai, hoc_van, kinh_nghiem, dia_chi, ky_nang
+#   ten, tuoi, email, dien_thoai, hoc_van, kinh_nghiem, dia_chi, ky_nang, vi_tri
 CV_EXTRACTION_PROMPT = (
     "Bạn là trợ lý AI chuyên trích xuất thông tin từ CV. "  # vai trò và nhiệm vụ của AI
-    "Hãy trả về JSON với các khóa: ten, tuoi, email, dien_thoai, hoc_van, kinh_nghiem, dia_chi, ky_nang. "  # yêu cầu định dạng đầu ra
+    "Hãy trả về JSON với các khóa: ten, tuoi, email, dien_thoai, hoc_van, kinh_nghiem, dia_chi, ky_nang, vi_tri. "  # yêu cầu định dạng đầu ra
     "Ví dụ:\n"  # phần ví dụ minh họa
     "```json\n"  # bắt đầu code block JSON
     '{\n'  # mở object JSON
@@ -16,7 +16,8 @@ CV_EXTRACTION_PROMPT = (
     '  "hoc_van": "Đại học Bách Khoa TP.HCM, CNTT",\n'  # trường học vấn
     '  "kinh_nghiem": "3 năm tại Công ty XYZ",\n'  # trường kinh nghiệm
     '  "dia_chi": "1 Dai Lo, Thu Duc, TP.HCM",\n'  # trường địa chỉ
-    '  "ky_nang": "Python; Machine Learning"\n'  # trường kỹ năng
+    '  "ky_nang": "Python; Machine Learning",\n'  # trường kỹ năng
+    '  "vi_tri": "Kỹ sư Phần mềm"\n'  # trường vị trí ứng tuyển
     "}\n"  # đóng object JSON
     "```"  # kết thúc code block
 )

--- a/test/test_cv_processor.py
+++ b/test/test_cv_processor.py
@@ -47,7 +47,7 @@ def cv_processor_class(mock_pandas, mock_requests, monkeypatch):
 
 @pytest.mark.parametrize('text,expected', [
     (
-        """Họ tên: Nguyen Van A\nTuổi: 30\nEmail: a@test.com\nĐiện thoại: +84987654321\nĐịa chỉ: 123 Street\nHọc vấn: University ABC\nKinh nghiệm: 5 năm\nKỹ năng: Python""",
+        """Họ tên: Nguyen Van A\nTuổi: 30\nEmail: a@test.com\nĐiện thoại: +84987654321\nVị trí: Kỹ sư phần mềm\nĐịa chỉ: 123 Street\nHọc vấn: University ABC\nKinh nghiệm: 5 năm\nKỹ năng: Python""",
         {
             'ten': 'Nguyen Van A',
             'tuoi': '30',
@@ -57,11 +57,12 @@ def cv_processor_class(mock_pandas, mock_requests, monkeypatch):
             'kinh_nghiem': '5 năm',
             'dia_chi': '123 Street',
             'ky_nang': 'Python',
+            'vi_tri': 'Kỹ sư phần mềm',
         }
     ),
     (
 
-        """Họ tên: John Smith\nAge: 35\nEmail: john@example.com\nĐiện thoại: 555-123-4567\nAddress: 1 Main St\nEducation: BSc\nExperience: 3 years\nSkills: Java""",
+        """Họ tên: John Smith\nAge: 35\nEmail: john@example.com\nĐiện thoại: 555-123-4567\nPosition: Data Engineer\nAddress: 1 Main St\nEducation: BSc\nExperience: 3 years\nSkills: Java""",
         {
             'ten': 'John Smith',
             'tuoi': '35',
@@ -71,6 +72,7 @@ def cv_processor_class(mock_pandas, mock_requests, monkeypatch):
             'kinh_nghiem': '3 years',
             'dia_chi': '1 Main St',
             'ky_nang': 'Java',
+            'vi_tri': 'Data Engineer',
         }
     )
 ])


### PR DESCRIPTION
## Summary
- support `vi_tri` key in CV extraction prompt
- parse job position using regex fallback
- ensure compatibility with fetchers not accepting progress callback
- update tests for new `vi_tri` field

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686621fbfd1483249deffc8af755d1e1