### PR TITLE
Improve IMAP connection handling

### DIFF
--- a/src/main_engine/app.py
+++ b/src/main_engine/app.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import logging
 import traceback
 import time
+import types
 from typing import Optional, Dict, Any
 
 # Đưa thư mục gốc (chứa `modules/`) vào sys.path để import modules
@@ -68,11 +69,23 @@ try:
     )
 
     try:
-        from .tabs import fetch_process_tab, single_tab, results_tab, update_tab, cv_viewer_tab
+        from .tabs import fetch_process_tab, single_tab, results_tab
     except ImportError as ie:
         logger.error(f"Failed to import core tabs: {ie}")
         st.error(f"Lỗi import tabs: {ie}")
         st.stop()
+
+    try:
+        from .tabs import update_tab  # Optional tab
+    except ImportError:
+        update_tab = types.SimpleNamespace(render=lambda *a, **k: None)
+        logger.info("update_tab not available")
+
+    try:
+        from .tabs import cv_viewer_tab  # Optional tab
+    except ImportError:
+        cv_viewer_tab = types.SimpleNamespace(render=lambda *a, **k: None)
+        logger.info("cv_viewer_tab not available")
 
     try:
         from .tabs import chat_tab  # noqa: F401

--- a/src/main_engine/tabs/fetch_process_tab.py
+++ b/src/main_engine/tabs/fetch_process_tab.py
@@ -42,8 +42,8 @@ def render(
         st.warning("Cần nhập Gmail và mật khẩu trong sidebar để fetch CV.")
         fetcher = None
     else:
+        # Chỉ tạo đối tượng EmailFetcher, kết nối khi người dùng bắt đầu fetch
         fetcher = EmailFetcher(EMAIL_HOST, EMAIL_PORT, email_user, email_pass)
-        fetcher.connect()
 
     col1, col2 = st.columns(2)
     today_str = date.today().strftime("%d/%m/%Y")
@@ -61,6 +61,10 @@ def render(
 
     if st.button("Fetch & Process", help="Tải email và phân tích CV"):
         logging.info("Bắt đầu fetch & process CV")
+        if fetcher is None:
+            st.error("Cần nhập Gmail và mật khẩu trong sidebar để fetch CV.")
+            return
+
         from_dt = (
             datetime.combine(
                 datetime.strptime(from_date_str, "%d/%m/%Y"),
@@ -85,6 +89,16 @@ def render(
         # Tạo progress bar và status text
         progress_bar = st.progress(0)
         status_text = st.empty()
+        status_text.text("🔌 Đang kết nối IMAP...")
+
+        try:
+            fetcher.connect()
+        except Exception as e:
+            progress_bar.empty()
+            status_text.empty()
+            st.error(f"Không thể kết nối IMAP: {e}")
+            return
+
         status_text.text("🚀 Chuẩn bị khởi động...")
         
         def progress_callback(current, total, message):

--- a/test_update_system.py
+++ b/test_update_system.py
@@ -49,13 +49,13 @@ def test_update_system():
             print(f"⚠️ CLI có vấn đề: {result.stderr}")
         
         print("\n🎉 Tất cả test passed! Update system sẵn sàng sử dụng.")
-        return True
+        assert True
         
     except Exception as e:
         print(f"❌ Test failed: {e}")
         import traceback
         traceback.print_exc()
-        return False
+        assert False, str(e)
 
 if __name__ == "__main__":
     test_update_system()


### PR DESCRIPTION
## Summary
- avoid reconnecting to IMAP on every UI refresh by connecting only when clicking **Fetch & Process**
- handle optional tabs in `app.py` so tests can stub them
- fix update system test to use assertions instead of return values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686631894d4c832490f58eb096108ec5