### PR TITLE
Optimize IMAP fetching and CV processing

### DIFF
--- a/src/modules/config.py
+++ b/src/modules/config.py
@@ -61,6 +61,17 @@ else:
 EMAIL_USER = _get_env("EMAIL_USER")
 EMAIL_PASS = _get_env("EMAIL_PASS")
 
+# Thư mục email và giới hạn ngày tìm kiếm
+EMAIL_FOLDER = _get_env("EMAIL_FOLDER", "INBOX")
+_raw_days = os.getenv("EMAIL_SEARCH_DAYS", "").split('#', 1)[0].strip()
+if _raw_days:
+    try:
+        EMAIL_SEARCH_DAYS = int(_raw_days)
+    except ValueError:
+        EMAIL_SEARCH_DAYS = 0
+else:
+    EMAIL_SEARCH_DAYS = 0
+
 # --- Tuỳ chọn quét email: chỉ UNSEEN hay tất cả ---
 def _get_bool(varname: str, default: bool = True) -> bool:
     val = os.getenv(varname)

--- a/src/modules/cv_processor.py
+++ b/src/modules/cv_processor.py
@@ -251,6 +251,10 @@ class CVProcessor:
             for fname, ts in load_sent_times().items()
         }
 
+        if self.fetcher and getattr(self.fetcher, "last_fetch_info", None):
+            for path, ts in self.fetcher.last_fetch_info:
+                sent_map[path] = ts or sent_map.get(path, "")
+
         # Lấy tất cả file trong thư mục attachment
         all_files = set(files)  # từ email
         if ATTACHMENT_DIR.exists():
@@ -318,14 +322,12 @@ class CVProcessor:
                 text = self.extract_text(file_path)
                 if not text.strip():
                     logger.warning(f"⚠️ No text extracted from {fname}")
-                    failed_count += 1
-                    continue
-
-                # Extract info using LLM
-                info = self.extract_info_with_llm(text)
-                if not info:
-                    logger.warning(f"⚠️ No info extracted from {fname}")
-                    info = self._fallback_regex(text)  # fallback
+                    info = {}
+                else:
+                    info = self.extract_info_with_llm(text)
+                    if not info:
+                        logger.warning(f"⚠️ No info extracted from {fname}")
+                        info = self._fallback_regex(text)  # fallback
 
                 # Prepare record
                 sent_time_str = sent_map.get(file_path, "")
@@ -346,6 +348,11 @@ class CVProcessor:
 
         # Create DataFrame
         df = pd.DataFrame(processed_data)
+        rename_map = {
+            "file_name": "Tên file",
+            "sent_time_display": "Thời gian nhận",
+        }
+        df = df.rename(columns=rename_map)
         
         # Log summary
         elapsed = time.time() - start_time

--- a/src/modules/email_fetcher.py
+++ b/src/modules/email_fetcher.py
@@ -11,8 +11,8 @@ from datetime import date, datetime, timezone, timedelta  # dùng để lọc em
 from typing import List, Optional, Tuple
 from email.utils import parsedate_to_datetime
 
-from .config import ATTACHMENT_DIR, EMAIL_UNSEEN_ONLY
-from .sent_time_store import record_sent_time
+from .config import ATTACHMENT_DIR, EMAIL_UNSEEN_ONLY, EMAIL_SEARCH_DAYS
+from .sent_time_store import record_sent_time, record_sent_times_bulk
 from .uid_store import load_last_uid, save_last_uid
 
 # --- Logger của module (tránh nhân đôi handler khi tạo nhiều instance) ---
@@ -122,9 +122,12 @@ class EmailFetcher:
 
         new_files: List[str] = []
         self.last_fetch_info = []
+        sent_time_updates: dict[str, str | None] = {}
 
         # --- Tìm email với optional SINCE và UID range ---
         criteria = ['UNSEEN'] if unseen_only else ['ALL']
+        if since is None and EMAIL_SEARCH_DAYS > 0:
+            since = date.today() - timedelta(days=EMAIL_SEARCH_DAYS)
         if since:
             criteria += ['SINCE', since.strftime('%d-%b-%Y')]
         if before:
@@ -154,28 +157,50 @@ class EmailFetcher:
         lower_keywords = [kw.lower() for kw in keywords]
         for start in range(0, len(email_ids), batch_size):
             batch = email_ids[start:start + batch_size]
+            id_set = b','.join(batch)
+            # Fetch subject headers for the whole batch
+            if hasattr(self.mail, 'uid'):
+                h_typ, h_data = self.mail.uid('fetch', id_set, '(BODY.PEEK[HEADER.FIELDS (SUBJECT)])')
+            else:
+                h_typ, h_data = self.mail.fetch(id_set, '(BODY.PEEK[HEADER.FIELDS (SUBJECT)])')
+            if h_typ != 'OK' or not h_data:
+                continue
+
+            header_map: dict[str, str] = {}
+            for part in h_data:
+                if isinstance(part, tuple) and isinstance(part[1], (bytes, bytearray)):
+                    uid_match = re.search(br'UID\s+(\d+)', part[0] or b'') or re.search(br'^(\d+)', part[0] or b'')
+                    if not uid_match:
+                        continue
+                    uid = uid_match.group(1).decode()
+                    try:
+                        hdr = email.message_from_bytes(part[1])
+                        subj_hdr = hdr.get('Subject', '')
+                        subj = ''.join(
+                            p.decode(enc or 'utf-8', errors='ignore') if isinstance(p, bytes) else p
+                            for p, enc in decode_header(subj_hdr)
+                        )
+                    except Exception:
+                        subj = ''
+                    header_map[uid] = subj
+
             for num in batch:
-                # Fetch subject header first for quick filtering
-                if hasattr(self.mail, 'uid'):
-                    h_typ, h_data = self.mail.uid('fetch', num, '(BODY.PEEK[HEADER.FIELDS (SUBJECT)])')
-                else:
-                    h_typ, h_data = self.mail.fetch(num, '(BODY.PEEK[HEADER.FIELDS (SUBJECT)])')
-                if h_typ != 'OK' or not h_data:
-                    continue
-                subj = ''
-                for item in h_data:
-                    if isinstance(item, tuple) and isinstance(item[1], (bytes, bytearray)):
-                        try:
-                            hdr = email.message_from_bytes(item[1])
-                            subj_hdr = hdr.get('Subject', '')
-                            subj = ''.join(
-                                p.decode(enc or 'utf-8', errors='ignore') if isinstance(p, bytes) else p
-                                for p, enc in decode_header(subj_hdr)
-                            )
-                        except Exception:
-                            subj = ''
+                uid_str = num.decode() if isinstance(num, bytes) else str(num)
+                subj = header_map.get(uid_str, '')
                 if not any(kw in subj.lower() for kw in lower_keywords):
                     continue
+
+                # Fetch full message and INTERNALDATE only when subject matches
+                if hasattr(self.mail, 'uid'):
+                    typ, msg_data = self.mail.uid('fetch', num, '(RFC822 INTERNALDATE)')
+                    uid_int = int(num)
+                else:
+                    typ, msg_data = self.mail.fetch(num, '(RFC822 INTERNALDATE)')
+                    uid_int = int(num)
+                if typ != "OK" or not msg_data:
+                    continue
+                if uid_int > max_uid_seen:
+                    max_uid_seen = uid_int
 
                 # Fetch full message and INTERNALDATE only when subject matches
                 if hasattr(self.mail, 'uid'):
@@ -299,10 +324,7 @@ class EmailFetcher:
                         f.write(part.get_payload(decode=True))
                     new_files.append(path)
                     self.last_fetch_info.append((path, sent_time))
-                    try:
-                        record_sent_time(path, sent_time)
-                    except Exception as e:
-                        self.logger.warning(f"Could not record sent time for {path}: {e}")
+                    sent_time_updates[path] = sent_time
                     self.logger.info(f"[OK] Lưu đính kèm mới: {path}")
 
                 # Đánh dấu email đã đọc để tránh xử lý lại lần sau
@@ -313,6 +335,12 @@ class EmailFetcher:
 
         if not new_files:
             self.logger.info("[INFO] Không tìm thấy đính kèm mới.")
+
+        if sent_time_updates:
+            try:
+                record_sent_times_bulk(sent_time_updates)
+            except Exception as e:
+                self.logger.warning(f"Could not record sent times: {e}")
 
         if max_uid_seen:
             try:

--- a/src/modules/sent_time_store.py
+++ b/src/modules/sent_time_store.py
@@ -27,3 +27,15 @@ def record_sent_time(path: str, sent_time: str | None) -> None:
     data[fname] = sent_time or ""  # cập nhật thời gian gửi
     with open(SENT_TIME_FILE, "w", encoding="utf-8") as f:
         json.dump(data, f, ensure_ascii=False, indent=2)
+
+
+def record_sent_times_bulk(mapping: Dict[str, str | None]) -> None:
+    """Ghi nhiều bản ghi thời gian gửi cùng lúc."""
+    if not mapping:
+        return
+    data = load_sent_times()
+    for path, ts in mapping.items():
+        fname = os.path.basename(path)
+        data[fname] = ts or ""
+    with open(SENT_TIME_FILE, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)

--- a/test/test_email_fetcher.py
+++ b/test/test_email_fetcher.py
@@ -55,11 +55,12 @@ def test_fetch_cv_attachments(email_fetcher_module, tmp_path):
                 self.last_criteria = criteria
                 return 'OK', [b'1']
             if cmd.lower() == 'fetch':
-                num = args[0]
+                id_set = args[0]
                 query = args[1]
                 self.fetch_queries.append(query)
                 if query == '(BODY.PEEK[HEADER.FIELDS (SUBJECT)])':
-                    return 'OK', [(None, b'Subject: CV Nguyen\r\n')]
+                    ids = id_set.split(b',') if isinstance(id_set, bytes) else [id_set]
+                    return 'OK', [(b'UID %s' % i, b'Subject: CV Nguyen\r\n') for i in ids]
                 return 'OK', [
                     (None, raw),
                     (b'INTERNALDATE', b'"20-Sep-2023 10:20:00 -0400"'),
@@ -101,10 +102,12 @@ def test_profile_file_processed(email_fetcher_module, tmp_path):
             if cmd.lower() == 'search':
                 return 'OK', [b'1']
             if cmd.lower() == 'fetch':
+                id_set = args[0]
                 query = args[1]
                 self.fetch_queries.append(query)
                 if query == '(BODY.PEEK[HEADER.FIELDS (SUBJECT)])':
-                    return 'OK', [(None, b'Subject: Profile\r\n')]
+                    ids = id_set.split(b',') if isinstance(id_set, bytes) else [id_set]
+                    return 'OK', [(b'UID %s' % i, b'Subject: Profile\r\n') for i in ids]
                 return 'OK', [
                     (None, raw),
                     (b'INTERNALDATE', b'"20-Sep-2023 10:20:00 -0400"'),


### PR DESCRIPTION
## Summary
- add EMAIL_SEARCH_DAYS and EMAIL_FOLDER config variables
- batch IMAP header fetches and write sent-time metadata in bulk
- preserve attachments' sent times via `last_fetch_info`
- keep CV records even when text extraction fails and rename columns for clarity
- update tests for new IMAP batch behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68665492c9e88324a475d614f6345899