### PR TITLE
Ensure position extraction across project

### DIFF
--- a/src/modules/cv_processor.py
+++ b/src/modules/cv_processor.py
@@ -207,6 +207,7 @@ class CVProcessor:
             "tuoi": r"(?:(?:Tuổi|Age)[:\-\s]+)(\d{1,3})",
             "email": r"([a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+)",
             "dien_thoai": r"(\+?\d[\d\-\s]{7,}\d)",
+            "vi_tri": r"(?:(?:Vị trí|Position)[:\-\s]+)([^\n]+)",
             "hoc_van": r"(?:(?:Học vấn|Education)[:\-\s]+)([^\n]+)",
             "kinh_nghiem": r"(?:(?:Kinh nghiệm|Experience)[:\-\s]+)([^\n]+)",
             "dia_chi": r"(?:(?:Địa chỉ|Address)[:\-\s]+)([^\n]+)",
@@ -311,9 +312,13 @@ class CVProcessor:
             "Kinh nghiệm",
             "Kỹ năng",
         ])  # tạo DataFrame từ list dict với thứ tự cột cố định
-        if "Thời gian nhận" in df.columns:
+        if hasattr(df, "sort_values"):
             df.sort_values("Thời gian nhận", ascending=False, inplace=True)
             df["Thời gian nhận"] = df["Thời gian nhận"].apply(format_sent_time_display)
+        else:
+            df.sort(key=lambda r: r.get("Thời gian nhận", ""), reverse=True)
+            for row in df:
+                row["Thời gian nhận"] = format_sent_time_display(row.get("Thời gian nhận", ""))
         return df  # trả về kết quả
 
     def save_to_csv(self, df: pd.DataFrame, output: str = OUTPUT_CSV):

--- a/src/modules/prompts.py
+++ b/src/modules/prompts.py
@@ -2,10 +2,10 @@
 
 # Định nghĩa prompt cho LLM để trích xuất thông tin từ CV
 # Yêu cầu kết quả trả về dưới dạng JSON với các khóa:
-#   ten, tuoi, email, dien_thoai, hoc_van, kinh_nghiem, dia_chi, ky_nang
+#   ten, tuoi, email, dien_thoai, vi_tri, hoc_van, kinh_nghiem, dia_chi, ky_nang
 CV_EXTRACTION_PROMPT = (
     "Bạn là trợ lý AI chuyên trích xuất thông tin từ CV. "  # vai trò và nhiệm vụ của AI
-    "Hãy trả về JSON với các khóa: ten, tuoi, email, dien_thoai, hoc_van, kinh_nghiem, dia_chi, ky_nang. "  # yêu cầu định dạng đầu ra
+    "Hãy trả về JSON với các khóa: ten, tuoi, email, dien_thoai, vi_tri, hoc_van, kinh_nghiem, dia_chi, ky_nang. "  # yêu cầu định dạng đầu ra
     "Ví dụ:\n"  # phần ví dụ minh họa
     "```json\n"  # bắt đầu code block JSON
     '{\n'  # mở object JSON
@@ -13,6 +13,7 @@ CV_EXTRACTION_PROMPT = (
     '  "tuoi": "30",\n'  # trường tuổi
     '  "email": "a.van.nguyen@example.com",\n'  # trường email
     '  "dien_thoai": "+84 912345678",\n'  # trường điện thoại
+    '  "vi_tri": "Lập trình viên",\n'  # trường vị trí ứng tuyển
     '  "hoc_van": "Đại học Bách Khoa TP.HCM, CNTT",\n'  # trường học vấn
     '  "kinh_nghiem": "3 năm tại Công ty XYZ",\n'  # trường kinh nghiệm
     '  "dia_chi": "1 Dai Lo, Thu Duc, TP.HCM",\n'  # trường địa chỉ


### PR DESCRIPTION
## Summary
- include `vi_tri` in CV extraction prompt
- handle DummyDataFrame in `process` to always format sent time

## Testing
- `pytest test/test_cv_processor.py -q`
- `pytest -q` *(fails: ModuleNotFoundError for optional modules)*

------
https://chatgpt.com/codex/tasks/task_e_68673e8511ec832486f7cf75d1834a0f