### PR TITLE
Fix email fetch filter

### DIFF
--- a/src/main_engine/chat.py
+++ b/src/main_engine/chat.py
@@ -9,7 +9,10 @@ import streamlit as st
 
 from modules.config import OUTPUT_CSV
 from modules.progress_manager import StreamlitProgressBar
-from modules.qa_chatbot import QAChatbot
+try:
+    from modules.qa_chatbot import QAChatbot
+except Exception:  # pragma: no cover - optional dependency may be missing
+    QAChatbot = None
 from .utils import handle_error, safe_session_state_get
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- adjust QAChatbot import to handle missing module
- broaden keywords for email search
- prefetch email headers for subject filtering
- allow CV files named profile.pdf

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686b29063d4c8324a89b9defb87f14e3