### PR TITLE
Adjust CV attachment filters

### DIFF
--- a/src/modules/email_fetcher.py
+++ b/src/modules/email_fetcher.py
@@ -116,7 +116,7 @@ class EmailFetcher:
             raise RuntimeError("Chưa kết nối IMAP. Gọi connect() trước.")
 
         if keywords is None:
-            keywords = ["CV", "Resume", "Curriculum Vitae", "Profile"]
+            keywords = ["CV", "Resume", "Curriculum Vitae"]
 
         new_files: List[str] = []
         self.last_fetch_info = []
@@ -276,7 +276,7 @@ class EmailFetcher:
                     name, ext = os.path.splitext(filename)
                     if ext.lower() not in ['.pdf', '.docx']:
                         continue
-                    if not re.search(r"(cv|resume|profile)", name, re.IGNORECASE):
+                    if not re.search(r"(cv|resume)", name, re.IGNORECASE):
                         continue
                     safe_name = re.sub(r'[^\w\-\_ ]', '_', name)
                     safe = safe_name + ext

--- a/test/test_email_fetcher.py
+++ b/test/test_email_fetcher.py
@@ -122,6 +122,6 @@ def test_profile_file_processed(email_fetcher_module, tmp_path):
     fetcher.mail = imap
     files = fetcher.fetch_cv_attachments()
     expected = tmp_path / 'profile.pdf'
-    assert files == [str(expected)]
-    assert expected.exists()
+    assert files == []
+    assert not expected.exists()
 


### PR DESCRIPTION
## Summary
- narrow EmailFetcher to only match `cv` or `resume` filenames
- update default keyword list
- adapt test for new behavior

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b2ec5400c83248181b903860f197e