### PR TITLE
Make fetch/process buttons uniform

### DIFF
--- a/src/main_engine/tabs/fetch_process_tab.py
+++ b/src/main_engine/tabs/fetch_process_tab.py
@@ -95,8 +95,8 @@ def render(
     
     st.divider()  # Tạo đường phân cách
     
-    # Tạo 3 cột cho các nút bấm
-    col_btn1, col_btn2, col_btn3 = st.columns([2, 2, 1])
+    # Tạo 3 cột cho các nút bấm với kích thước đều nhau
+    col_btn1, col_btn2, col_btn3 = st.columns(3)
     
     # Cột 3: Nút Reset UID
     with col_btn3:


### PR DESCRIPTION
## Summary
- align the Fetch, Process, and Reset UID buttons with equal column sizes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'scripts'; ValueError: Missing email configuration)*

------
https://chatgpt.com/codex/tasks/task_e_686b6df55c2c8324888e8b402f3943c1